### PR TITLE
Remove unused safe_parser gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     jbuilder-schema (1.0.3)
       jbuilder
       rails (>= 5.0.0)
-      safe_parser
 
 GEM
   remote: https://rubygems.org/
@@ -167,11 +166,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    ruby_parser (3.8.4)
-      sexp_processor (~> 4.1)
-    safe_parser (1.0.0)
-      ruby_parser (~> 3.8.4)
-    sexp_processor (4.16.1)
     standard (1.14.0)
       rubocop (= 1.32.0)
       rubocop-performance (= 1.14.3)

--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "jbuilder"
-  spec.add_dependency "safe_parser"
 
   spec.add_dependency "rails", ">= 5.0.0"
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -3,7 +3,6 @@
 require "jbuilder/jbuilder_template"
 require "active_support/inflections"
 require "active_support/core_ext/hash/deep_transform_values"
-require "safe_parser"
 
 module JbuilderSchema
   # Template parser class


### PR DESCRIPTION
Can't spot `SafeParser.new.safe_load` being used anywhere, and it seems like it's an old version of YAML/Psych far as I could tell.