### PR TITLE
Slim jbuilder overrides

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -283,8 +283,7 @@ module JbuilderSchema
     end
 
     def _is_collection_array?(object)
-      # TODO: Find better way to determine if all array elements are models
-      object.is_a?(Array) && object.map { |a| _is_active_model?(a) }.uniq == [true]
+      object.is_a?(Array) && object.all? { _is_active_model? _1 }
     end
 
     def _required!(keys)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -217,10 +217,12 @@ module JbuilderSchema
     FORMATS = {DateTime => "date-time", ActiveSupport::TimeWithZone => "date-time", Date => "date", Time => "time"}
 
     def _schema(key, value, **options)
-      options.merge!(_guess_type(value)) unless options[:type]
+      unless options[:type]
+        options.merge!(_guess_type(value))
 
-      if format = FORMATS[value.class]
-        options[:format] = format
+        if format = FORMATS[value.class]
+          options[:format] = format
+        end
       end
 
       if models.last&.defined_enums&.keys&.include?(key.to_s)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -336,14 +336,13 @@ module JbuilderSchema
 end
 
 class Jbuilder
-  # Monkey-patch for Jbuilder::KeyFormatter to ignore schema keys
-  class KeyFormatter
-    alias_method :original_format, :format
+  module SkipFormatting
+    SCHEMA_KEYS = %i[type items properties]
 
     def format(key)
-      return key if %i[type items properties].include?(key)
-
-      original_format(key)
+      SCHEMA_KEYS.include?(key) ? key : super
     end
   end
+
+  KeyFormatter.prepend SkipFormatting
 end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -223,15 +223,11 @@ module JbuilderSchema
     end
 
     def _guess_type(value)
-      type = value.class.name&.downcase&.to_sym
-
-      case type
-      when :datetime, :"activesupport::timewithzone"
-        {type: :string, format: "date-time"}
-      when :time, :date
-        {type: :string, format: type.to_s}
-      when :array
-        _guess_array_types(value)
+      case value
+      when DateTime, ActiveSupport::TimeWithZone then {type: :string, format: "date-time"}
+      when Time then {type: :string, format: "time"}
+      when Date then {type: :string, format: "date"}
+      when Array then _guess_array_types(value)
       else
         {type: _primitive_type(value)}
       end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -160,7 +160,7 @@ module JbuilderSchema
     end
 
     def cache!(key = nil, **options)
-      yield
+      yield # TODO: Our schema generation breaks Jbuilder's fragment caching.
     end
 
     def method_missing(*args, &block)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -198,22 +198,20 @@ module JbuilderSchema
     end
 
     def _set_ref(component)
+      component_path = "#/#{JbuilderSchema.configuration.components_path}/#{component}"
+
       if @inline_array
         if @collection
           _set_value(:type, :array)
-          _set_value(:items, {:$ref => _component_path(component)})
+          _set_value(:items, {:$ref => component_path})
         else
           _set_value(:type, :object)
-          _set_value(:$ref, _component_path(component))
+          _set_value(:$ref, component_path)
         end
       else
         @type = :array
-        _set_value(:items, {:$ref => _component_path(component)})
+        _set_value(:items, {:$ref => component_path})
       end
-    end
-
-    def _component_path(component)
-      "#/#{JbuilderSchema.configuration.components_path}/#{component}"
     end
 
     def _schema(key, value, **options)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -238,15 +238,11 @@ module JbuilderSchema
     end
 
     def _guess_array_types(array)
-      hash = {type: :array}
-      types = array.map { _type _1 }.uniq
-
-      unless types.empty?
-        hash[:contains] = {type: types.size > 1 ? types : types.first}
-        hash[:minContains] = 0
+      if (types = array.map { _type _1 }.uniq).any?
+        {type: :array, minContains: 0, contains: {type: types.many? ? types : types.first}}
+      else
+        {type: :array}
       end
-
-      hash
     end
 
     def _type(type)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -237,7 +237,7 @@ module JbuilderSchema
       end
 
       if (model = model_scope.model) && (defined_enum = model.try(:defined_enums)&.dig(key.to_s))
-        options[:enum] = define_enum.keys
+        options[:enum] = defined_enum.keys
       end
 
       options

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -163,7 +163,7 @@ module JbuilderSchema
       yield # TODO: Our schema generation breaks Jbuilder's fragment caching.
     end
 
-    def method_missing(*args, &block)
+    def method_missing(*args, &block) # standard:disable Style/MissingRespondToMissing
       args, schema_options = _args_and_schema_options(*args)
 
       if block

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -220,6 +220,11 @@ module JbuilderSchema
       unless options[:type]
         options.merge!(_guess_type(value))
 
+        if value.is_a?(Array) && (types = value.map { _primitive_type _1 }.uniq).any?
+          options[:minContains] = 0
+          options[:contains] = {type: types.many? ? types : types.first}
+        end
+
         if format = FORMATS[value.class]
           options[:format] = format
         end
@@ -237,11 +242,7 @@ module JbuilderSchema
     end
 
     def _guess_array_types(array)
-      if (types = array.map { _primitive_type _1 }.uniq).any?
-        {type: :array, minContains: 0, contains: {type: types.many? ? types : types.first}}
-      else
-        {type: :array}
-      end
+      {type: :array}
     end
 
     def _primitive_type(type)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -233,19 +233,19 @@ module JbuilderSchema
       when :array
         _guess_array_types(value)
       else
-        {type: _type(value)}
+        {type: _primitive_type(value)}
       end
     end
 
     def _guess_array_types(array)
-      if (types = array.map { _type _1 }.uniq).any?
+      if (types = array.map { _primitive_type _1 }.uniq).any?
         {type: :array, minContains: 0, contains: {type: types.many? ? types : types.first}}
       else
         {type: :array}
       end
     end
 
-    def _type(type)
+    def _primitive_type(type)
       case type
       when Float, BigDecimal then :number
       when true, false       then :boolean

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -187,7 +187,7 @@ module JbuilderSchema
         type: :object,
         title: model_scope.i18n_title,
         description: model_scope.i18n_description,
-        required: _required!(**attributes),
+        required: _required!(attributes.keys),
         properties: attributes
       }
     end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -236,8 +236,8 @@ module JbuilderSchema
         format = FORMATS[value.class] and options[:format] ||= format
       end
 
-      if (model = model_scope.model) && model.respond_to?(:defined_enums) && model.defined_enums&.keys&.include?(key.to_s)
-        options[:enum] = model&.defined_enums[key.to_s].keys
+      if (model = model_scope.model) && (defined_enum = model.try(:defined_enums)&.dig(key.to_s))
+        options[:enum] = define_enum.keys
       end
 
       options

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -218,9 +218,9 @@ module JbuilderSchema
 
     def _schema(key, value, **options)
       unless options[:type]
-        options.merge!(_guess_type(value))
+        options[:type] = _primitive_type value
 
-        if value.is_a?(Array) && (types = value.map { _primitive_type _1 }.uniq).any?
+        if options[:type] == :array && (types = value.map { _primitive_type _1 }.uniq).any?
           options[:minContains] = 0
           options[:contains] = {type: types.many? ? types : types.first}
         end
@@ -237,16 +237,9 @@ module JbuilderSchema
       options
     end
 
-    def _guess_type(value)
-      value.is_a?(Array) ? _guess_array_types(value) : {type: _primitive_type(value)}
-    end
-
-    def _guess_array_types(array)
-      {type: :array}
-    end
-
     def _primitive_type(type)
       case type
+      when Array             then :array
       when Float, BigDecimal then :number
       when true, false       then :boolean
       when Integer           then :integer

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -96,7 +96,7 @@ module JbuilderSchema
 
     def extract!(object, *attributes, schema: {})
       if ::Hash === object
-        _extract_hash_values(object, attributes, **schema)
+        _extract_hash_values(object, attributes, schema: schema)
       else
         _extract_method_values(object, attributes, schema: schema)
       end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -245,10 +245,10 @@ module JbuilderSchema
 
     def _primitive_type(type)
       case type
-      when Array             then :array
+      when Array then :array
       when Float, BigDecimal then :number
-      when true, false       then :boolean
-      when Integer           then :integer
+      when true, false then :boolean
+      when Integer then :integer
       else
         :string
       end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -230,7 +230,7 @@ module JbuilderSchema
         end
       end
 
-      if models.last&.defined_enums&.keys&.include?(key.to_s)
+      if (model = models.last) && model.respond_to?(:defined_enums) && model.defined_enums&.keys&.include?(key.to_s)
         options[:enum] = models.last&.defined_enums[key.to_s].keys
       end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -233,9 +233,7 @@ module JbuilderSchema
           options[:contains] = {type: types.many? ? types : types.first}
         end
 
-        if format = FORMATS[value.class]
-          options[:format] = format
-        end
+        options[:format] ||= FORMATS[value.class]
       end
 
       if (model = model_scope.model) && model.respond_to?(:defined_enums) && model.defined_enums&.keys&.include?(key.to_s)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -214,8 +214,14 @@ module JbuilderSchema
       end
     end
 
+    FORMATS = {DateTime => "date-time", ActiveSupport::TimeWithZone => "date-time", Date => "date", Time => "time"}
+
     def _schema(key, value, **options)
       options.merge!(_guess_type(value)) unless options[:type]
+
+      if format = FORMATS[value.class]
+        options[:format] = format
+      end
 
       if models.last&.defined_enums&.keys&.include?(key.to_s)
         options[:enum] = models.last&.defined_enums[key.to_s].keys
@@ -226,9 +232,9 @@ module JbuilderSchema
 
     def _guess_type(value)
       case value
-      when DateTime, ActiveSupport::TimeWithZone then {type: :string, format: "date-time"}
-      when Time then {type: :string, format: "time"}
-      when Date then {type: :string, format: "date"}
+      when DateTime, ActiveSupport::TimeWithZone then {type: :string}
+      when Time then {type: :string}
+      when Date then {type: :string}
       when Array then _guess_array_types(value)
       else
         {type: _primitive_type(value)}

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -233,13 +233,13 @@ module JbuilderSchema
       when :array
         _guess_array_types(value)
       else
-        {type: _type(type)}
+        {type: _type(value)}
       end
     end
 
     def _guess_array_types(array)
       hash = {type: :array}
-      types = array.map { |a| _type(a.class.name&.downcase&.to_sym) }.uniq
+      types = array.map { _type _1 }.uniq
 
       unless types.empty?
         hash[:contains] = {type: types.size > 1 ? types : types.first}
@@ -251,12 +251,9 @@ module JbuilderSchema
 
     def _type(type)
       case type
-      when :float, :bigdecimal
-        :number
-      when :trueclass, :falseclass
-        :boolean
-      when :integer
-        :integer
+      when Float, BigDecimal then :number
+      when true, false       then :boolean
+      when Integer           then :integer
       else
         :string
       end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -216,7 +216,11 @@ module JbuilderSchema
 
     def _schema(key, value, **options)
       options.merge!(_guess_type(value)) unless options[:type]
-      options.merge!(_set_enum(key.to_s)) if models.last&.defined_enums&.keys&.include?(key.to_s)
+
+      if models.last&.defined_enums&.keys&.include?(key.to_s)
+        options[:enum] = models.last&.defined_enums[key.to_s].keys
+      end
+
       options
     end
 
@@ -247,11 +251,6 @@ module JbuilderSchema
       else
         :string
       end
-    end
-
-    def _set_enum(key)
-      enums = models.last&.defined_enums[key].keys
-      {enum: enums}
     end
 
     def _make_array(collection, *args, **schema_options, &block)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -297,6 +297,7 @@ module JbuilderSchema
     ###
 
     def _key(key)
+      # TODO: Plain Jbuilder generates string keys, are we doing something here that'll bite us later?
       @key_formatter ? @key_formatter.format(key).to_sym : key.to_sym
     end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -188,7 +188,7 @@ module JbuilderSchema
     end
 
     def _args_and_schema_options(*args)
-      schema_options = args.extract! { |a| a.is_a?(::Hash) && a.key?(:schema) }.first.try(:[], :schema) || {}
+      schema_options = args.extract! { |a| a.is_a?(::Hash) && a.key?(:schema) }.first&.dig(:schema) || {}
       [args, schema_options]
     end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -41,16 +41,13 @@ module JbuilderSchema
           @inline_array = true
           if schema_options.key?(:object)
             models << schema_options[:object].class
-            titles << schema_options[:object_title] || nil
-            descriptions << schema_options[:object_description] || nil
+            titles << schema_options[:object_title]
+            descriptions << schema_options[:object_description]
           end
-          r = _merge_block(key) { yield self }
-          if schema_options.key?(:object)
-            models.pop
-            titles.pop
-            descriptions.pop
+
+          _merge_block(key) { yield self }.tap do
+            [models, titles, descriptions].each(&:pop) if schema_options.key?(:object)
           end
-          r
         end
       elsif args.empty?
         if ::Jbuilder === value

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -233,7 +233,7 @@ module JbuilderSchema
           options[:contains] = {type: types.many? ? types : types.first}
         end
 
-        options[:format] ||= FORMATS[value.class]
+        format = FORMATS[value.class] and options[:format] ||= format
       end
 
       if (model = model_scope.model) && model.respond_to?(:defined_enums) && model.defined_enums&.keys&.include?(key.to_s)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -231,14 +231,7 @@ module JbuilderSchema
     end
 
     def _guess_type(value)
-      case value
-      when DateTime, ActiveSupport::TimeWithZone then {type: :string}
-      when Time then {type: :string}
-      when Date then {type: :string}
-      when Array then _guess_array_types(value)
-      else
-        {type: _primitive_type(value)}
-      end
+      value.is_a?(Array) ? _guess_array_types(value) : {type: _primitive_type(value)}
     end
 
     def _guess_array_types(array)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -94,13 +94,11 @@ module JbuilderSchema
       _set_value key, result
     end
 
-    def extract!(object, *attributes, **schema_options)
-      schema_options = schema_options[:schema] if schema_options.key?(:schema)
-
+    def extract!(object, *attributes, schema: {})
       if ::Hash === object
-        _extract_hash_values(object, attributes, **schema_options)
+        _extract_hash_values(object, attributes, **schema)
       else
-        _extract_method_values(object, attributes, **schema_options)
+        _extract_method_values(object, attributes, schema: schema)
       end
     end
 
@@ -112,7 +110,7 @@ module JbuilderSchema
         @collection = true
         _set_ref(options[:partial].split("/").last)
       else
-        array = _make_array(collection, *args, **schema_options, &block)
+        array = _make_array(collection, *args, schema: schema_options, &block)
 
         if @inline_array
           @attributes = {}
@@ -248,13 +246,13 @@ module JbuilderSchema
       end
     end
 
-    def _make_array(collection, *args, **schema_options, &block)
+    def _make_array(collection, *args, schema: {}, &block)
       if collection.nil?
         []
       elsif block
         _map_collection(collection, &block)
       elsif args.any?
-        _map_collection(collection) { |element| extract! element, *args, **schema_options }
+        _map_collection(collection) { |element| extract! element, *args, schema: schema }
       else
         _format_keys(collection.to_a)
       end
@@ -278,17 +276,17 @@ module JbuilderSchema
       @key_formatter ? @key_formatter.format(key).to_sym : key.to_sym
     end
 
-    def _extract_hash_values(object, attributes, **schema_options)
+    def _extract_hash_values(object, attributes, schema:)
       attributes.each do |key|
-        result = _schema(key, _format_keys(object.fetch(key)), **schema_options[key] || {})
+        result = _schema(key, _format_keys(object.fetch(key)), **schema[key] || {})
         result = _set_description(key, result) if models.any?
         _set_value key, result
       end
     end
 
-    def _extract_method_values(object, attributes, **schema_options)
+    def _extract_method_values(object, attributes, schema:)
       attributes.each do |key|
-        result = _schema(key, _format_keys(object.public_send(key)), **schema_options[key] || {})
+        result = _schema(key, _format_keys(object.public_send(key)), **schema[key] || {})
         result = _set_description(key, result) if models.any?
         _set_value key, result
       end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -173,10 +173,6 @@ module JbuilderSchema
       end
     end
 
-    def respond_to_missing?(method_name, include_private = false)
-      super
-    end
-
     private
 
     def _object(**attributes)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -9,14 +9,14 @@ module JbuilderSchema
   class Template < ::JbuilderTemplate
     attr_reader :attributes, :type, :models, :titles, :descriptions
 
-    def initialize(*args, **options)
+    def initialize(*args, model: nil, title: nil, description: nil)
       @type = :object
       @inline_array = false
       @collection = false
 
-      @models = [options.delete(:model)]
-      @titles = [options.delete(:title)]
-      @descriptions = [options.delete(:description)]
+      @models = [model]
+      @titles = [title]
+      @descriptions = [description]
 
       super(nil, *args)
 

--- a/test/fixtures/api/v1/articles/_article.jbuilder
+++ b/test/fixtures/api/v1/articles/_article.jbuilder
@@ -1,1 +1,1 @@
-json.extract! article, :id, :title, :body, :created_at, :updated_at, schema: {body: {type: :string, pattern: /\w+/}}
+json.extract! article, :id, :status, :title, :body, :created_at, :updated_at, schema: {body: {type: :string, pattern: /\w+/}}

--- a/test/fixtures/api/v1/articles/_article.jbuilder
+++ b/test/fixtures/api/v1/articles/_article.jbuilder
@@ -1,1 +1,1 @@
-json.extract! article, :id, :title, :body, :created_at, :updated_at, schema: { body: { type: :string, pattern: /\w+/ } }
+json.extract! article, :id, :title, :body, :created_at, :updated_at, schema: {body: {type: :string, pattern: /\w+/}}

--- a/test/jbuilder/schema/builder_test.rb
+++ b/test/jbuilder/schema/builder_test.rb
@@ -6,13 +6,13 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
   include JbuilderSchema
 
   setup do
-    I18n.backend.store_translations "en", articles: { fields: {
-      id: { description: "en.articles.fields.id.description" },
-      title: { description: "en.articles.fields.title.description" },
-      body: { description: "en.articles.fields.body.description" },
-      created_at: { description: "en.articles.fields.created_at.description" },
-      updated_at: { description: "en.articles.fields.updated_at.description" },
-    } }
+    I18n.backend.store_translations "en", articles: {fields: {
+      id: {description: "en.articles.fields.id.description"},
+      title: {description: "en.articles.fields.title.description"},
+      body: {description: "en.articles.fields.body.description"},
+      created_at: {description: "en.articles.fields.created_at.description"},
+      updated_at: {description: "en.articles.fields.updated_at.description"}
+    }}
   end
 
   teardown { I18n.reload! }
@@ -26,7 +26,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
       model: Article,
       description: "Article in the blog",
       paths: ["test/fixtures"],
-      locals: { article: article, current_user: user }
+      locals: {article: article, current_user: user}
 
     assert_equal({
       type: :object,
@@ -38,7 +38,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
         title: {type: :string, description: "en.articles.fields.title.description"},
         body: {type: :string, description: "en.articles.fields.body.description", pattern: /\w+/},
         created_at: {type: :string, description: "en.articles.fields.created_at.description", format: "date-time"},
-        updated_at: {type: :string, description: "en.articles.fields.updated_at.description", format: "date-time"},
+        updated_at: {type: :string, description: "en.articles.fields.updated_at.description", format: "date-time"}
       }
     }, schema)
   end
@@ -53,7 +53,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
       description: "Article in the blog",
       format: :yaml,
       paths: ["test/fixtures"],
-      locals: { article: article, current_user: user }
+      locals: {article: article, current_user: user}
 
     assert_equal <<~YAML, schema
       ---
@@ -94,7 +94,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
       description: "Article in the blog",
       format: :json,
       paths: ["test/fixtures"],
-      locals: { article: article, current_user: user }
+      locals: {article: article, current_user: user}
 
     assert_equal({
       type: "object",
@@ -106,7 +106,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
         title: {type: "string", description: "en.articles.fields.title.description"},
         body: {type: "string", description: "en.articles.fields.body.description", pattern: "\\w+"},
         created_at: {type: "string", description: "en.articles.fields.created_at.description", format: "date-time"},
-        updated_at: {type: "string", description: "en.articles.fields.updated_at.description", format: "date-time"},
+        updated_at: {type: "string", description: "en.articles.fields.updated_at.description", format: "date-time"}
       }
     }, JSON.parse(schema, symbolize_names: true))
   end

--- a/test/jbuilder/schema/builder_test.rb
+++ b/test/jbuilder/schema/builder_test.rb
@@ -8,6 +8,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
   setup do
     I18n.backend.store_translations "en", articles: {fields: {
       id: {description: "en.articles.fields.id.description"},
+      status: {description: "en.articles.fields.status.description"},
       title: {description: "en.articles.fields.title.description"},
       body: {description: "en.articles.fields.body.description"},
       created_at: {description: "en.articles.fields.created_at.description"},
@@ -35,6 +36,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
       required: [:id],
       properties: {
         id: {type: :integer, description: "en.articles.fields.id.description"},
+        status: {type: :string, description: "en.articles.fields.status.description", enum: ["pending", "published", "archived"]},
         title: {type: :string, description: "en.articles.fields.title.description"},
         body: {type: :string, description: "en.articles.fields.body.description", pattern: /\w+/},
         created_at: {type: :string, description: "en.articles.fields.created_at.description", format: "date-time"},
@@ -66,6 +68,13 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
         id:
           description: en.articles.fields.id.description
           type: integer
+        status:
+          description: en.articles.fields.status.description
+          type: string
+          enum:
+          - pending
+          - published
+          - archived
         title:
           description: en.articles.fields.title.description
           type: string
@@ -103,6 +112,7 @@ class JbuilderSchema::BuilderTest < ActiveSupport::TestCase
       required: ["id"],
       properties: {
         id: {type: "integer", description: "en.articles.fields.id.description"},
+        status: {type: "string", description: "en.articles.fields.status.description", enum: ["pending", "published", "archived"]},
         title: {type: "string", description: "en.articles.fields.title.description"},
         body: {type: "string", description: "en.articles.fields.body.description", pattern: "\\w+"},
         created_at: {type: "string", description: "en.articles.fields.created_at.description", format: "date-time"},

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -57,6 +57,22 @@ class TemplateTest < ActiveSupport::TestCase
     assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result.attributes)
   end
 
+  test "json.extract! with hash" do
+    result = JbuilderSchema::Template.new(model: Hash) do |json|
+      json.extract!({ id: 1, title: "sup", body: "somebody once told me the world…" }, :id, :title, :body)
+    end
+
+    assert_equal({id: {description: "test", type: :integer}, title: {description: "test", type: :string}, body: {description: "test", type: :string}}, result.attributes)
+  end
+
+  test "json.extract! with hash and schema arguments" do
+    result = JbuilderSchema::Template.new(model: Hash) do |json|
+      json.extract!({ id: 1, title: "sup", body: "somebody once told me the world…" }, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
+    end
+
+    assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result.attributes)
+  end
+
   test "simple block" do
     result = JbuilderSchema::Template.new(model: User) do |json|
       json.author { json.id 123 }

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -4,8 +4,7 @@ require "test_helper"
 require "jbuilder/schema/template"
 
 class TemplateTest < ActiveSupport::TestCase
-  def setup
-    super
+  setup do
     I18n.stubs(:t).returns("test")
   end
 

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -58,7 +58,7 @@ class TemplateTest < ActiveSupport::TestCase
 
   test "json.extract! with hash" do
     result = JbuilderSchema::Template.new(model: Hash) do |json|
-      json.extract!({ id: 1, title: "sup", body: "somebody once told me the world…" }, :id, :title, :body)
+      json.extract!({id: 1, title: "sup", body: "somebody once told me the world…"}, :id, :title, :body)
     end
 
     assert_equal({id: {description: "test", type: :integer}, title: {description: "test", type: :string}, body: {description: "test", type: :string}}, result.attributes)
@@ -66,7 +66,7 @@ class TemplateTest < ActiveSupport::TestCase
 
   test "json.extract! with hash and schema arguments" do
     result = JbuilderSchema::Template.new(model: Hash) do |json|
-      json.extract!({ id: 1, title: "sup", body: "somebody once told me the world…" }, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
+      json.extract!({id: 1, title: "sup", body: "somebody once told me the world…"}, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
     end
 
     assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result.attributes)
@@ -156,11 +156,11 @@ class TemplateTest < ActiveSupport::TestCase
     assert_equal({
       description: "test", type: :array,
       items: {id: {description: "test", type: :integer},
-      title: {description: "test", type: :string},
-      body: {description: "test", type: :string},
-      created_at: {description: "test", type: :string, format: "date-time"},
-      updated_at: {description: "test", type: :string, format: "date-time"},
-      user_id: {description: "test", type: :integer}}
+              title: {description: "test", type: :string},
+              body: {description: "test", type: :string},
+              created_at: {description: "test", type: :string, format: "date-time"},
+              updated_at: {description: "test", type: :string, format: "date-time"},
+              user_id: {description: "test", type: :integer}}
     }, json.articles(articles))
   end
 

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -156,6 +156,7 @@ class TemplateTest < ActiveSupport::TestCase
     assert_equal({
       description: "test", type: :array,
       items: {id: {description: "test", type: :integer},
+              status: {description: "test", type: :string, enum: ["pending", "published", "archived"]},
               title: {description: "test", type: :string},
               body: {description: "test", type: :string},
               created_at: {description: "test", type: :string, format: "date-time"},

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define do
 
   create_table :articles, force: true do |t|
     t.references :user
+    t.string :status, default: "pending", null: false
     t.string :title, null: false
     t.text :body, null: false
     t.timestamps null: false
@@ -31,6 +32,8 @@ end
 
 class Article < ActiveRecord::Base
   belongs_to :user
+
+  enum :status, %i[ pending published archived ]
 
   def as_json(options = {})
     super(only: %i[id title body])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,4 +13,3 @@ require "mocha/minitest"
 require "setup/active_record"
 
 ActiveSupport.test_order = :random
-ActiveSupport::TimeWithZone.singleton_class.remove_method(:name) # Remove after Rails 7.1 release


### PR DESCRIPTION
I'm just starting on this to try to find ways to slim our complex Jbuilder overrides, since that's makes the library tougher to maintain and then it's more of a risk for users to depend on in their apps.

Eventually I'm hoping to make most of `Template` disappear and instead provide something like:

```ruby
json.extract! @article, :id, :title, :body # Let Jbuilder have it's nice DSL as a one-liner, and we can derive what schema we can from here, but don't accept custom schema options in every method…

# …instead expose a `schema!` method for specific overrides.
json.schema! do |schema|
  schema.id description: "x"
end
```

An API like ^ also makes it easier to turn off the schema generation in production where it's not needed, i.e. `def schema!; end # no needless yielding` and since each method has no `schema` knowledge, it doesn't have to compute any of that either 🚀