### PR TITLE
Return hash output (useful for command-line testing at least)

### DIFF
--- a/lib/jbuilder/schema.rb
+++ b/lib/jbuilder/schema.rb
@@ -25,12 +25,16 @@ class Jbuilder::Schema
       yield self
     end
 
+    def hash(path, **options)
+      normalize(load(path, **options))
+    end
+
     def yaml(path, **options)
-      normalize(load(path, **options)).to_yaml
+      hash(path, **options).to_yaml
     end
 
     def json(path, **options)
-      normalize(load(path, **options)).to_json
+      hash(path, **options).to_json
     end
 
     def load(path, paths: ["app/views"], **options)


### PR DESCRIPTION
@kaspth First of all, let me thank you for your refactoring work, it's very impressive and I'm learning a lot! 
---
It seems the pure Ruby Hash output was removed, but I used it a lot to debug code in command line, it's much more readable than yaml or json strings. Here I return it back as `Jbuilder::Schema.hash`.