### PR TITLE
Fix _key method when formatting keys

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -279,7 +279,7 @@ class Jbuilder::Schema
 
     def _key(key)
       # TODO: Plain Jbuilder generates string keys, are we doing something here that'll bite us later?
-      @key_formatter ? @key_formatter.format(key).to_sym : key.to_sym
+      @key_formatter ? @key_formatter.format(key).to_sym : key&.to_sym
     end
 
     def _extract_hash_values(object, attributes, schema:)


### PR DESCRIPTION
Also I'm not sure what happened, but even when we have simple template like
```ruby
json.extract! article, :id, :title, :body
```
we get the next error: 
```ruby
jbuilder-schema/lib/jbuilder/schema/template.rb:282:in `_key': undefined method `to_sym' for nil:NilClass (NoMethodError)

      @key_formatter ? @key_formatter.format(key).to_sym : key.to_sym
                                                              ^^^^^^^
```
I don't even know how `key` can be nil here. @kaspth Any ideas?

---

Here I just use safe navigation to avoid this and keep tests running and my console debugs work, but that doesn't feel like the right fix.