### PR TITLE
Finish converting `schema:` to keyword arguments

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -105,15 +105,12 @@ class Jbuilder::Schema
       end
     end
 
-    def array!(collection = [], *args, &block)
-      args, schema_options = _args_and_schema_options(*args)
-      options = args.first
-
-      if args.one? && _partial_options?(options)
+    def array!(collection = [], *args, schema: {}, **options, &block)
+      if _partial_options?(options)
         @collection = true
         _set_ref(options[:partial].split("/").last)
       else
-        array = _make_array(collection, *args, schema: schema_options, &block)
+        array = _make_array(collection, *args, schema: schema, &block)
 
         if @inline_array
           @attributes = {}
@@ -183,11 +180,6 @@ class Jbuilder::Schema
         required: _required!(attributes.keys),
         properties: attributes
       }
-    end
-
-    def _args_and_schema_options(*args)
-      schema_options = args.extract! { |a| a.is_a?(::Hash) && a.key?(:schema) }.first&.dig(:schema) || {}
-      [args, schema_options]
     end
 
     def _set_description(key, value)

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -73,7 +73,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
   end
 
   test "object without schema attributes" do
-    result = Jbuilder::Schema::Template.new(nil, model: Article) do |json|
+    result = Jbuilder::Schema::Template.new(model: Article) do |json|
       json.user User.first, :id, :name
     end
 
@@ -81,7 +81,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
   end
 
   test "object with schema attributes" do
-    result = Jbuilder::Schema::Template.new(nil, model: Article) do |json|
+    result = Jbuilder::Schema::Template.new(model: Article) do |json|
       json.user User.first, :id, :name, schema: {object: User.first, object_title: "User", object_description: "User writes articles"}
     end
 

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -72,6 +72,22 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
     assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result.attributes)
   end
 
+  test "object without schema attributes" do
+    result = Jbuilder::Schema::Template.new(nil, model: Article) do |json|
+      json.user User.first, :id, :name
+    end
+
+    assert_equal({user: {type: :object, title: "test", description: "test", required: [:id], properties: {id: {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result.attributes)
+  end
+
+  test "object with schema attributes" do
+    result = Jbuilder::Schema::Template.new(nil, model: Article) do |json|
+      json.user User.first, :id, :name, schema: {object: User.first, object_title: "User", object_description: "User writes articles"}
+    end
+
+    assert_equal({user: {type: :object, title: "User", description: "User writes articles", required: [:id], properties: {id: {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result.attributes)
+  end
+
   test "simple block" do
     result = Jbuilder::Schema::Template.new(model: User) do |json|
       json.author { json.id 123 }


### PR DESCRIPTION
Fixes #10

When we'd converted `**schema_options` to `schema:` in `extract!`, we
still passed them unwrapped to `extract!` in `set!`, so this continues
the migration to keyword arguments.

Then we add the missing tests.