### PR TITLE
Follow Jbuilder's default to use String keys

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -298,12 +298,9 @@ class Jbuilder::Schema
       current_value = _blank? ? BLANK : @attributes.fetch(_key(key), BLANK)
       raise NullError.build(key) if current_value.nil?
 
-      new_value = _scope { yield self }
-      unless new_value.key?(:type) && new_value[:type] == :array || new_value.key?(:$ref)
-        new_value_properties = new_value
-        new_value = _object(**new_value_properties)
-      end
-      _merge_values(current_value, new_value)
+      value = _scope { yield self }
+      value = _object(**value) unless value.values_at("type", :type).any?(:array) || value.key?(:$ref) || value.key?("$ref")
+      _merge_values(current_value, value)
     end
   end
 end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -274,11 +274,6 @@ class Jbuilder::Schema
     # Jbuilder methods
     ###
 
-    def _key(key)
-      # TODO: Plain Jbuilder generates string keys, are we doing something here that'll bite us later?
-      @key_formatter ? @key_formatter.format(key).to_sym : key.to_sym
-    end
-
     def _extract_hash_values(object, attributes, schema:)
       attributes.each do |key|
         result = _schema(key, _format_keys(object.fetch(key)), **schema[key] || {})

--- a/test/jbuilder/schema/builder_test.rb
+++ b/test/jbuilder/schema/builder_test.rb
@@ -28,14 +28,14 @@ class Jbuilder::Schema::BuilderTest < ActiveSupport::TestCase
       type: :object,
       title: "Article",
       description: "Article in the blog",
-      required: [:id],
+      required: ["id"],
       properties: {
-        id: {type: :integer, description: "en.articles.fields.id.description"},
-        status: {type: :string, description: "en.articles.fields.status.description", enum: ["pending", "published", "archived"]},
-        title: {type: :string, description: "en.articles.fields.title.description"},
-        body: {type: :string, description: "en.articles.fields.body.description", pattern: /\w+/},
-        created_at: {type: :string, description: "en.articles.fields.created_at.description", format: "date-time"},
-        updated_at: {type: :string, description: "en.articles.fields.updated_at.description", format: "date-time"}
+        "id" => {type: :integer, description: "en.articles.fields.id.description"},
+        "status" => {type: :string, description: "en.articles.fields.status.description", enum: ["pending", "published", "archived"]},
+        "title" => {type: :string, description: "en.articles.fields.title.description"},
+        "body" => {type: :string, description: "en.articles.fields.body.description", pattern: /\w+/},
+        "created_at" => {type: :string, description: "en.articles.fields.created_at.description", format: "date-time"},
+        "updated_at" => {type: :string, description: "en.articles.fields.updated_at.description", format: "date-time"}
       }
     }, schema)
   end

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -77,7 +77,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user User.first, :id, :name
     end
 
-    assert_equal({"user" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
+    assert_equal({"user" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "object with schema attributes" do
@@ -85,7 +85,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user User.first, :id, :name, schema: {object: User.first, object_title: "User", object_description: "User writes articles"}
     end
 
-    assert_equal({"user" => {type: :object, title: "User", description: "User writes articles", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
+    assert_equal({"user" => {type: :object, title: "User", description: "User writes articles", required: ["id"], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "simple block" do
@@ -93,7 +93,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.author { json.id 123 }
     end
 
-    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}}}}, result)
   end
 
   test "block with schema object attribute" do
@@ -103,7 +103,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}}}}, result)
   end
 
   test "block with array" do
@@ -146,7 +146,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "block with partial" do

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -146,7 +146,8 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
+    # TODO: should the merged name be a symbol or string here? E.g. should it pass through `_key`?
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result)
   end
 
   test "block with partial" do
@@ -168,8 +169,8 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
   end
 
   test "collections" do
-    assert_equal({description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}, json.articles(articles, :id, :title))
-    assert_equal({description: "test", type: :array, items: {
+    assert_equal({description: "test", "type" => :array, "items" => {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}, json.articles(articles, :id, :title))
+    assert_equal({description: "test", "type" => :array, "items" => {
       "id" => {description: "test", type: :integer},
       "status" => {description: "test", type: :string, enum: ["pending", "published", "archived"]},
       "title" => {description: "test", type: :string},
@@ -209,7 +210,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       }
     end
 
-    assert_equal({"Id" => {description: "test", type: :integer}, "Title" => {description: "test", type: :string}, "Author" => {type: :object, title: "test", description: "test", required: [:Id], properties: {"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}}}}, result)
+    assert_equal({"Id" => {description: "test", type: :integer}, "Title" => {description: "test", type: :string}, "Author" => {type: :object, title: "test", description: "test", required: ["Id"], properties: {"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}}}}, result)
   end
 
   test "deep key format with array" do

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -111,7 +111,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.articles { json.array! Article.first(3), :id, :title }
     end
 
-    assert_equal({"articles" => {description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}}, result)
+    assert_equal({"articles" => {description: "test", "type" => :array, "items" => {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}}, result)
   end
 
   test "array with block" do
@@ -155,7 +155,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user { json.partial! "api/v1/users/user", user: User.first }
     end
 
-    assert_equal({"user" => {description: "test", type: :object, "$ref": "#/components/schemas/user"}}, result)
+    assert_equal({"user" => {description: "test", "type" => :object, "$ref" => "#/components/schemas/user"}}, result)
   end
 
   test "block with array with partial" do
@@ -165,7 +165,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({"articles" => {description: "test", type: :array, items: {:$ref => "#/components/schemas/article"}}}, result)
+    assert_equal({"articles" => {description: "test", "type" => :array, "items" => {:$ref => "#/components/schemas/article"}}}, result)
   end
 
   test "collections" do

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -45,7 +45,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.extract!(articles.first, :id, :title, :body)
     end
 
-    assert_equal({id: {description: "test", type: :integer}, title: {description: "test", type: :string}, body: {description: "test", type: :string}}, result)
+    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}, result)
   end
 
   test "json.extract! with schema arguments" do
@@ -53,7 +53,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.extract!(articles.first, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
     end
 
-    assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result)
+    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :text}}, result)
   end
 
   test "json.extract! with hash" do
@@ -61,7 +61,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.extract!({id: 1, title: "sup", body: "somebody once told me the world…"}, :id, :title, :body)
     end
 
-    assert_equal({id: {description: "test", type: :integer}, title: {description: "test", type: :string}, body: {description: "test", type: :string}}, result)
+    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}, result)
   end
 
   test "json.extract! with hash and schema arguments" do
@@ -69,7 +69,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.extract!({id: 1, title: "sup", body: "somebody once told me the world…"}, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
     end
 
-    assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}, result)
+    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :text}}, result)
   end
 
   test "object without schema attributes" do
@@ -77,7 +77,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user User.first, :id, :name
     end
 
-    assert_equal({user: {type: :object, title: "test", description: "test", required: [:id], properties: {id: {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result)
+    assert_equal({"user" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "object with schema attributes" do
@@ -85,7 +85,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user User.first, :id, :name, schema: {object: User.first, object_title: "User", object_description: "User writes articles"}
     end
 
-    assert_equal({user: {type: :object, title: "User", description: "User writes articles", required: [:id], properties: {id: {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result)
+    assert_equal({"user" => {type: :object, title: "User", description: "User writes articles", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "simple block" do
@@ -93,7 +93,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.author { json.id 123 }
     end
 
-    assert_equal({author: {type: :object, title: "test", description: "test", required: [:id], properties: {id: {description: "test", type: :integer}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}}}}, result)
   end
 
   test "block with schema object attribute" do
@@ -103,7 +103,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({author: {type: :object, title: "test", description: "test", required: [:id], properties: {id: {description: "test", type: :integer}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}}}}, result)
   end
 
   test "block with array" do
@@ -111,7 +111,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.articles { json.array! Article.first(3), :id, :title }
     end
 
-    assert_equal({articles: {description: "test", type: :array, items: {id: {description: "test", type: :integer}, title: {description: "test", type: :string}}}}, result)
+    assert_equal({"articles" => {description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}}, result)
   end
 
   test "array with block" do
@@ -123,7 +123,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({items: {id: {description: "test", type: :integer}, title: {description: "test", type: :string}, body: {description: "test", type: :string}}}, result)
+    assert_equal({"items" => {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}}, result)
   end
 
   test "array with block with schema attributes" do
@@ -135,7 +135,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({items: {id: {description: "test", type: :string}, title: {description: "test", type: :string}, body: {description: "test", type: :text}}}, result)
+    assert_equal({"items" => {"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :text}}}, result)
   end
 
   test "block with merge" do
@@ -146,7 +146,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({author: {type: :object, title: "test", description: "test", required: [:id], properties: {id: {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result)
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: [:id], properties: {"id" => {description: "test", type: :integer}, "name" => {description: "test", type: :string}}}}, result)
   end
 
   test "block with partial" do
@@ -154,7 +154,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.user { json.partial! "api/v1/users/user", user: User.first }
     end
 
-    assert_equal({user: {:description => "test", :type => :object, :$ref => "#/components/schemas/user"}}, result)
+    assert_equal({"user" => {description: "test", type: :object, "$ref": "#/components/schemas/user"}}, result)
   end
 
   test "block with array with partial" do
@@ -164,28 +164,27 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({articles: {description: "test", type: :array, items: {:$ref => "#/components/schemas/article"}}}, result)
+    assert_equal({"articles" => {description: "test", type: :array, items: {:$ref => "#/components/schemas/article"}}}, result)
   end
 
   test "collections" do
-    assert_equal({description: "test", type: :array, items: {id: {description: "test", type: :integer}, title: {description: "test", type: :string}}}, json.articles(articles, :id, :title))
-    assert_equal({
-      description: "test", type: :array,
-      items: {id: {description: "test", type: :integer},
-              status: {description: "test", type: :string, enum: ["pending", "published", "archived"]},
-              title: {description: "test", type: :string},
-              body: {description: "test", type: :string},
-              created_at: {description: "test", type: :string, format: "date-time"},
-              updated_at: {description: "test", type: :string, format: "date-time"},
-              user_id: {description: "test", type: :integer}}
+    assert_equal({description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}, json.articles(articles, :id, :title))
+    assert_equal({description: "test", type: :array, items: {
+      "id" => {description: "test", type: :integer},
+      "status" => {description: "test", type: :string, enum: ["pending", "published", "archived"]},
+      "title" => {description: "test", type: :string},
+      "body" => {description: "test", type: :string},
+      "created_at" => {description: "test", type: :string, format: "date-time"},
+      "updated_at" => {description: "test", type: :string, format: "date-time"},
+      "user_id" => {description: "test", type: :integer}}
     }, json.articles(articles))
   end
 
   test "jbuilder methods" do
     assert_equal({description: "test", type: :string}, json.set!(:name, "David"))
     assert_equal({:$ref => "#/components/schemas/article"}, json.partial!("articles/article", collection: articles, as: :article))
-    assert_equal({id: {description: "test", type: :integer}, title: {description: "test", type: :string}}, json.array!(articles, :id, :title))
-    assert_equal({id: {description: "test", type: :string}, title: {description: "test", type: :string}}, json.array!(articles, :id, :title, schema: {id: {type: :string}}))
+    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}, json.array!(articles, :id, :title))
+    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}}, json.array!(articles, :id, :title, schema: {id: {type: :string}}))
   end
 
   test "key format" do
@@ -195,7 +194,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.name "David"
     end
 
-    assert_equal({Id: {description: "test", type: :integer}, Name: {description: "test", type: :string}}, result)
+    assert_equal({"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}}, result)
   end
 
   test "deep key format" do
@@ -210,7 +209,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       }
     end
 
-    assert_equal({Id: {description: "test", type: :integer}, Title: {description: "test", type: :string}, Author: {type: :object, title: "test", description: "test", required: [:Id], properties: {Id: {description: "test", type: :integer}, Name: {description: "test", type: :string}}}}, result)
+    assert_equal({"Id" => {description: "test", type: :integer}, "Title" => {description: "test", type: :string}, "Author" => {type: :object, title: "test", description: "test", required: [:Id], properties: {"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}}}}, result)
   end
 
   test "deep key format with array" do
@@ -222,7 +221,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.articles articles, :title, :created_at
     end
 
-    assert_equal({Id: {description: "test", type: :integer}, Name: {description: "test", type: :string}, Articles: {description: "test", type: :array, items: {Title: {description: "test", type: :string}, CreatedAt: {description: "test", type: :string, format: "date-time"}}}}, result)
+    assert_equal({"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}, "Articles" => {description: "test", type: :array, items: {"Title" => {description: "test", type: :string}, "CreatedAt" => {description: "test", type: :string, format: "date-time"}}}}, result)
   end
 
   test "schematize type" do


### PR DESCRIPTION
Fixes #11

@newstler this brings us to some of what we spoke about in #11. I think it's a better default to follow what Jbuilder does out of the box. However, we still have `_object` that uses symbols. I think I'll look into that kind of thing in a follow up.