### PR TITLE
Add missing version require

### DIFF
--- a/lib/jbuilder/schema.rb
+++ b/lib/jbuilder/schema.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/module/delegation"
+require "jbuilder/schema/version"
 
 class Jbuilder::Schema
   VERSION = JBUILDER_SCHEMA_VERSION # See `jbuilder/schema/version.rb`


### PR DESCRIPTION
I forgot this since in some gem loading the version was automatically required, but it doesn't seem to be through Bundler with

```ruby
github: "bullet-train-co/jbuilder-schema"
```