### PR TITLE
Allow Jbuilder::Schema::Template to coexist with regular Jbuilder

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -10,12 +10,20 @@ class Jbuilder::Schema
 
     class Handler < ::JbuilderHandler
       def self.call(template, source = nil)
-        super.sub("JbuilderTemplate.new(self", "Jbuilder::Schema::Template.new(self, **__jbuilder_schema_options").sub("target!", "schema!")
+        super.sub("JbuilderTemplate.new(self", "Jbuilder::Schema::Template.build(self, local_assigns")
       end
     end
 
     ::ActiveSupport.on_load :action_view do
       ::ActionView::Template.register_template_handler :jbuilder, ::Jbuilder::Schema::Template::Handler
+    end
+
+    def self.build(view_context, local_assigns)
+      if (options = local_assigns[:__jbuilder_schema_options])
+        new(view_context, **options)
+      else
+        ::JbuilderTemplate.new(view_context)
+      end
     end
 
     ModelScope = ::Struct.new(:model, :title, :description, keyword_init: true) do
@@ -47,6 +55,10 @@ class Jbuilder::Schema
       super(context)
 
       @ignore_nil = false
+    end
+
+    def target!
+      schema!
     end
 
     def schema!


### PR DESCRIPTION
Incase our Template override gets loaded, users can't perform regular Jbuilder renders anymore. This checks whether we've been passed the `__jbuilder_schema_options` as a secret handshake to let us know what rendering type to perform.

Note: this is pretty complex and I'd like to find a different way to handle all this.

Particularly if something like `render(handlers: :jbuilder_schema)` could work.

Fixes the type of build failure seen here: https://app.circleci.com/pipelines/github/bullet-train-co/bullet_train-base/499/workflows/ae554ebe-3986-409a-acbe-2d4641c4c4b4/jobs/2031

```
Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest#test_update:
ActionView::Template::Error: undefined local variable or method `__jbuilder_schema_options' for #<ActionView::Base:0x000000000573a0>

            @virtual_path = "api/v1/scaffolding/completely_concrete/tangible_things/show";;__already_defined = defined?(json); json||=Jbuilder::Schema::Template.new(self, **__jbuilder_schema_options); json.partial! "api/v1/scaffolding/completely_concrete/tangible_things/tangible_thing", tangible_thing: @tangible_thing
                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb:98:in `block in <class:TangibleThingsControllerTest>'


rails test test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb:96
```