### PR TITLE
Reduce `set!` override

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -66,7 +66,7 @@ class Jbuilder::Schema
 
       _with_configuration(**schema) do
         _with_schema_overrides(key => schema) do
-          super(key, value, *args, **options, &block)
+          super(key, value, *args.presence || _extract_possible_keys(value), **options, &block)
         end
       end
     end
@@ -119,6 +119,10 @@ class Jbuilder::Schema
     end
 
     private
+
+    def _extract_possible_keys(value)
+      value.first.as_json.keys if _is_collection?(value) && _is_active_model?(value.first)
+    end
 
     def _with_schema_overrides(overrides)
       old_schema_overrides, @schema_overrides = @schema_overrides, overrides if overrides

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -62,41 +62,13 @@ class Jbuilder::Schema
     end
 
     def set!(key, value = BLANK, *args, schema: {}, **options, &block)
-      result = if block
-        if !_blank?(value)
-          # json.comments @article.comments { |comment| ... }
-          # { "comments": [ { ... }, { ... } ] }
-          _scope { array! value, &block }
-        else
-          # json.comments { ... }
-          # { "comments": ... }
-          @inline_array = true
-          _merge_block_with_configuration(key, **schema) { yield self }
-        end
-      elsif args.empty?
-        if value.respond_to?(:all?) && value.all? { _is_active_model? _1 }
-          # json.articles @articles # TODO: Jbuilder doesn't automatically extract keys from a collection, should we add this feature?
-          _scope { array! value, *value.first.attribute_names }
-        else
-          # json.age 32
-          # json.person another_jbuilder
-          # { "age": 32, "person": { ...  }
-          value = ::Jbuilder === value ? value.attributes! : value
-          _schema(key, _format_keys(value), **schema)
-        end
-      elsif _is_collection?(value)
-        # json.comments @article.comments, :content, :created_at
-        # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
-        @inline_array = true
-        _scope { array! value, *args }
-      else
-        # json.author @article.creator, :name, :email_address
-        # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
-        _merge_block_with_configuration(key, **schema) { extract! value, *args, schema: schema }
-      end
+      @inline_array = true if block && _blank?(value) || _is_collection?(value)
 
-      _set_description key, result
-      _set_value key, result
+      _with_configuration(**schema) do
+        _with_schema_overrides(key => schema) do
+          super(key, value, *args, **options, &block)
+        end
+      end
     end
 
     def array!(collection = [], *args, schema: nil, **options, &block)
@@ -224,6 +196,7 @@ class Jbuilder::Schema
 
     def _set_value(key, value)
       value = _schema(key, value) unless value.is_a?(::Hash) && value.key?(:type)
+      _set_description(key, value)
       super
     end
 
@@ -232,19 +205,19 @@ class Jbuilder::Schema
       keys & [_key(:id), *presence_validated_attributes.map { _key _1 }]
     end
 
+    def _with_configuration(object: nil, object_title: nil, object_description: nil, **)
+      old_configuration, @configuration = @configuration, Configuration.new(model: object.class, title: object_title, description: object_description) if object
+      yield
+    ensure
+      @configuration = old_configuration if object
+    end
+
     ###
     # Jbuilder methods
     ###
 
     def _map_collection(collection)
       super.first
-    end
-
-    def _merge_block_with_configuration(key, object: nil, object_title: nil, object_description: nil, **, &block)
-      old_configuration, @configuration = @configuration, Configuration.new(model: object.class, title: object_title, description: object_description) if object
-      _merge_block(key, &block)
-    ensure
-      @configuration = old_configuration if object
     end
 
     def _merge_block(key)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -74,6 +74,7 @@ class Jbuilder::Schema
     ensure
       @configuration = old_configuration if old_configuration
     end
+    alias_method :method_missing, :set! # TODO: Remove once Jbuilder passes keyword arguments along to `set!` in its `method_missing`.
 
     def array!(collection = [], *args, schema: nil, **options, &block)
       if _partial_options?(options)
@@ -115,11 +116,6 @@ class Jbuilder::Schema
 
     def cache!(key = nil, **options)
       yield # TODO: Our schema generation breaks Jbuilder's fragment caching.
-    end
-
-    def method_missing(*args, **options, &block) # standard:disable Style/MissingRespondToMissing
-      # TODO: Remove once Jbuilder passes keyword arguments along to `set!` in its `method_missing`.
-      set!(*args, **options, &block)
     end
 
     private

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -152,18 +152,17 @@ class Jbuilder::Schema
     end
 
     def _set_ref(part, collection:)
-      component_path = "#/#{::Jbuilder::Schema.components_path}/#{part.split("/").last}"
+      ref = {"$ref": "#/#{::Jbuilder::Schema.components_path}/#{part.split("/").last}"}
       @attributes = {} if _blank?
 
-      if @inline_array
-        if collection&.any?
-          @attributes.merge! type: :array, items: {"$ref": component_path}
-        else
-          @attributes.merge! type: :object, "$ref": component_path
-        end
-      else
+      case
+      when !@inline_array
         @type = :array
-        @attributes[:items] = {"$ref": component_path}
+        @attributes[:items] = ref
+      when collection&.any?
+        @attributes.merge! type: :array, items: ref
+      else
+        @attributes.merge! type: :object, **ref
       end
     end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -48,8 +48,6 @@ class Jbuilder::Schema
 
     def initialize(context, **options)
       @type = :object
-      @inline_array = false
-
       @configuration = Configuration.new(**options)
 
       super(context)

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -135,7 +135,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({items: {"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :text}}}, result)
+    assert_equal({items: {"id" => {type: :string, description: "test"}, "title" => {type: :string, description: "test"}, "body" => {type: :text, description: "test"}}}, result)
   end
 
   test "block with merge" do

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -42,7 +42,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "json.extract!" do
     result = json_for(Article) do |json|
-      json.extract!(articles.first, :id, :title, :body)
+      json.extract!(Article.first, :id, :title, :body)
     end
 
     assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}, result)
@@ -50,7 +50,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "json.extract! with schema arguments" do
     result = json_for(Article) do |json|
-      json.extract!(articles.first, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
+      json.extract!(Article.first, :id, :title, :body, schema: {id: {type: :string}, body: {type: :text}})
     end
 
     assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :text}}, result)
@@ -98,7 +98,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "block with schema object attribute" do
     result = json_for(User) do |json|
-      json.author schema: {object: articles.first.user} do
+      json.author schema: {object: Article.first.user} do
         json.id 123
       end
     end
@@ -108,7 +108,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "block with array" do
     result = json_for(Article) do |json|
-      json.articles { json.array! Article.first(3), :id, :title }
+      json.articles { json.array! Article.all, :id, :title }
     end
 
     assert_equal({"articles" => {description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}}, result)
@@ -116,7 +116,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "array with block" do
     result = json_for(Article) do |json|
-      json.array! articles do |article|
+      json.array! Article.all do |article|
         json.id article.id
         json.title article.title
         json.body article.body
@@ -128,7 +128,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "array with block with schema attributes" do
     result = json_for(Article) do |json|
-      json.array! articles do |article|
+      json.array! Article.all do |article|
         json.id article.id, schema: {type: :string}
         json.title article.title
         json.body article.body, schema: {type: :text}
@@ -160,8 +160,8 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "block with array with partial" do
     result = json_for(Article) do |json|
-      json.articles schema: {object: articles.first} do
-        json.array! articles, partial: "api/v1/articles/article", as: :article
+      json.articles schema: {object: Article.first} do
+        json.array! Article.all, partial: "api/v1/articles/article", as: :article
       end
     end
 
@@ -169,7 +169,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
   end
 
   test "collections" do
-    assert_equal({description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}, json.articles(articles, :id, :title))
+    assert_equal({description: "test", type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}}, json.articles(Article.all, :id, :title))
     assert_equal({description: "test", type: :array, items: {
       "id" => {description: "test", type: :integer},
       "status" => {description: "test", type: :string, enum: ["pending", "published", "archived"]},
@@ -178,14 +178,14 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       "created_at" => {description: "test", type: :string, format: "date-time"},
       "updated_at" => {description: "test", type: :string, format: "date-time"},
       "user_id" => {description: "test", type: :integer}}
-    }, json.articles(articles))
+    }, json.articles(Article.all))
   end
 
   test "jbuilder methods" do
     assert_equal({description: "test", type: :string}, json.set!(:name, "David"))
-    assert_equal({:$ref => "#/components/schemas/article"}, json.partial!("articles/article", collection: articles, as: :article))
-    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}, json.array!(articles, :id, :title))
-    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}}, json.array!(articles, :id, :title, schema: {id: {type: :string}}))
+    assert_equal({:$ref => "#/components/schemas/article"}, json.partial!("articles/article", collection: Article.all, as: :article))
+    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title))
+    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title, schema: {id: {type: :string}}))
   end
 
   test "pass through of internal instance variables" do
@@ -238,7 +238,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       json.deep_format_keys!
       json.id 123
       json.name "David"
-      json.articles articles, :title, :created_at
+      json.articles Article.all, :title, :created_at
     end
 
     assert_equal({"Id" => {description: "test", type: :integer}, "Name" => {description: "test", type: :string}, "Articles" => {description: "test", type: :array, items: {"Title" => {description: "test", type: :string}, "CreatedAt" => {description: "test", type: :string, format: "date-time"}}}}, result)
@@ -264,7 +264,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
   end
 
   test "schema! with array" do
-    json = json { _1.array! articles, :title }
+    json = json { _1.array! Article.all, :title }
     assert_equal({type: :array, items: {"title" => {type: :string, description: "test"}}}, json.schema!)
   end
 
@@ -276,9 +276,5 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   def json(&block)
     Jbuilder::Schema::Template.new(nil, model: Article, &block)
-  end
-
-  def articles
-    Article.first(3)
   end
 end

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -27,7 +27,7 @@ end
 class User < ActiveRecord::Base
 end
 
-5.times do |n|
+3.times do |n|
   User.create! name: "Generic name #{n}", email: "user-#{n}@example.com"
 end
 
@@ -37,6 +37,6 @@ class Article < ActiveRecord::Base
   enum :status, %i[ pending published archived ]
 end
 
-5.times do |n|
+3.times do |n|
   Article.create! user: User.first, title: "Generic title #{n}", body: "Lorem ipsum… #{n}"
 end

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define do
 end
 
 class User < ActiveRecord::Base
+  has_many :articles
 end
 
 3.times do |n|
@@ -38,5 +39,5 @@ class Article < ActiveRecord::Base
 end
 
 3.times do |n|
-  Article.create! user: User.first, title: "Generic title #{n}", body: "Lorem ipsum… #{n}"
+  User.first.articles.create! title: "Generic title #{n}", body: "Lorem ipsum… #{n}"
 end

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -35,10 +35,6 @@ class Article < ActiveRecord::Base
   belongs_to :user
 
   enum :status, %i[ pending published archived ]
-
-  def as_json(options = {})
-    super(only: %i[id title body])
-  end
 end
 
 5.times do |n|


### PR DESCRIPTION
This reduces the nitty-gritty override of Jbuilder's `set!` method, instead relying on setting up some specific context we need and then calling `super`.

We do need to specialize the `json.articles Article.all` with no explicit arguments provided case. — as a bonus we now pipe that through `as_json` instead of `attribute_names` bringing us closer to Jbuilder's handling.

There's probably room for more cleanup here after this.