### PR TITLE
Reduce state management

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -80,9 +80,7 @@ class Jbuilder::Schema
         partial!(collection: collection, **options)
       else
         _with_schema_overrides(schema) do
-          @attributes = {} if _blank?
-          @attributes[:type] = :array
-          @attributes[:items] = _scope { super(collection, *args, &block) }
+          _attributes.merge! type: :array, items: _scope { super(collection, *args, &block) }
         end
       end
     end
@@ -146,13 +144,17 @@ class Jbuilder::Schema
 
     def _set_ref(part, collection:)
       ref = {"$ref": "#/#{::Jbuilder::Schema.components_path}/#{part.split("/").last}"}
-      @attributes = {} if _blank?
 
       if collection&.any?
-        @attributes.merge! type: :array, items: ref
+        _attributes.merge! type: :array, items: ref
       else
-        @attributes.merge! type: :object, **ref
+        _attributes.merge! type: :object, **ref
       end
+    end
+
+    def _attributes
+      @attributes = {} if _blank?
+      @attributes
     end
 
     FORMATS = {::DateTime => "date-time", ::ActiveSupport::TimeWithZone => "date-time", ::Date => "date", ::Time => "time"}

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -99,14 +99,8 @@ class Jbuilder::Schema
     end
 
     def merge!(object)
-      hash_or_array = ::Jbuilder === object ? object.attributes! : object
-      hash_or_array = _format_keys(hash_or_array)
-      if hash_or_array.is_a?(::Hash)
-        hash_or_array = hash_or_array.each_with_object({}) do |(key, value), a|
-          a[key] = _schema(key, value)
-        end
-      end
-      @attributes = _merge_values(@attributes, hash_or_array)
+      object = object.to_h { [_1, _schema(_1, _2)] } if object.is_a?(::Hash)
+      super
     end
 
     def cache!(key = nil, **options)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -68,8 +68,6 @@ class Jbuilder::Schema
       old_configuration, @configuration = @configuration, Configuration.build(**schema) if schema&.dig(:object)
 
       _with_schema_overrides(key => schema) do
-        @inline_array = true if block && _blank?(value) || _is_collection?(value)
-
         super(key, value, *args.presence || _extract_possible_keys(value), **options, &block)
       end
     ensure
@@ -150,7 +148,7 @@ class Jbuilder::Schema
       ref = {"$ref": "#/#{::Jbuilder::Schema.components_path}/#{part.split("/").last}"}
       @attributes = {} if _blank?
 
-      if !@inline_array || collection&.any?
+      if collection&.any?
         @attributes.merge! type: :array, items: ref
       else
         @attributes.merge! type: :object, **ref

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -82,7 +82,7 @@ class Jbuilder::Schema
         partial!(collection: collection, **options)
       else
         _with_schema_overrides(schema) do
-          @attributes = {} if blank?
+          @attributes = {} if _blank?
           @attributes[:type] = :array
           @attributes[:items] = _scope { super(collection, *args, &block) }
         end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -150,10 +150,7 @@ class Jbuilder::Schema
       ref = {"$ref": "#/#{::Jbuilder::Schema.components_path}/#{part.split("/").last}"}
       @attributes = {} if _blank?
 
-      case
-      when !@inline_array
-        @attributes[:items] = ref
-      when collection&.any?
+      if !@inline_array || collection&.any?
         @attributes.merge! type: :array, items: ref
       else
         @attributes.merge! type: :object, **ref

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -83,7 +83,7 @@ class Jbuilder::Schema
       else
         _with_schema_overrides(schema) do
           @attributes = {} if blank?
-          @attributes[:type] = :array unless ::Kernel.block_given?
+          @attributes[:type] = :array
           @attributes[:items] = _scope { super(collection, *args, &block) }
         end
       end

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -189,6 +189,14 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
     }, json.articles(Article.all))
   end
 
+  test "empty collections" do
+    result = json_for(User) do |json|
+      json.articles []
+    end
+
+    assert_equal({"articles" => {type: :array, items: {"$ref": "#/components/schemas/article"}, description: "test"}}, result)
+  end
+
   test "pass through of internal instance variables" do
     result = json_for(User) do |json|
       # Test our internal options don't bar someone from adding them to their JSON.

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -189,12 +189,6 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
     }, json.articles(Article.all))
   end
 
-  test "jbuilder methods" do
-    assert_equal({description: "test", type: :string}, json.set!(:name, "David"))
-    assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title))
-    assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title, schema: {id: {type: :string}}))
-  end
-
   test "pass through of internal instance variables" do
     result = json_for(User) do |json|
       # Test our internal options don't bar someone from adding them to their JSON.

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -150,6 +150,14 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
     assert_equal({"author" => {type: :object, title: "test", description: "test", required: ["id"], properties: {"id" => {description: "test", type: :integer}, name: {description: "test", type: :string}}}}, result)
   end
 
+  test "partial" do
+    result = json_for(Article) do |json|
+      json.partial! "articles/article", collection: Article.all, as: :article
+    end
+
+    assert_equal({type: :array, items: {"$ref": "#/components/schemas/article"}}, result)
+  end
+
   test "block with partial" do
     result = json_for(User) do |json|
       json.user { json.partial! "api/v1/users/user", user: User.first }
@@ -183,7 +191,6 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
 
   test "jbuilder methods" do
     assert_equal({description: "test", type: :string}, json.set!(:name, "David"))
-    assert_equal({:$ref => "#/components/schemas/article"}, json.partial!("articles/article", collection: Article.all, as: :article))
     assert_equal({"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title))
     assert_equal({"id" => {description: "test", type: :string}, "title" => {description: "test", type: :string}}, json.array!(Article.all, :id, :title, schema: {id: {type: :string}}))
   end

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -123,7 +123,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}}, result)
+    assert_equal({type: :array, items: {"id" => {description: "test", type: :integer}, "title" => {description: "test", type: :string}, "body" => {description: "test", type: :string}}}, result)
   end
 
   test "array with block with schema attributes" do
@@ -135,7 +135,7 @@ class Jbuilder::Schema::TemplateTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal({items: {"id" => {type: :string, description: "test"}, "title" => {type: :string, description: "test"}, "body" => {type: :text, description: "test"}}}, result)
+    assert_equal({type: :array, items: {"id" => {type: :string, description: "test"}, "title" => {type: :string, description: "test"}, "body" => {type: :text, description: "test"}}}, result)
   end
 
   test "block with merge" do


### PR DESCRIPTION
Mostly here to remove the need to separate out `@type` from `@attributes[:type]` and remove the need for `@inline_array`.