### PR TITLE
Fix for naming refs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    jbuilder-schema (2.3.0)
+    jbuilder-schema (2.3.1)
       jbuilder
-      rails (>= 5.0.0)
+      rails (>= 5.0.0, < 7.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -105,7 +105,7 @@ GEM
     minitest (5.20.0)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.3.7)
+    net-imap (0.4.0)
       date
       net-protocol
     net-pop (0.1.2)
@@ -119,7 +119,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     racc (1.7.1)
@@ -158,7 +158,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.8.1)
     rexml (3.2.6)
-    rubocop (1.56.3)
+    rubocop (1.56.4)
       base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -195,11 +195,11 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby

--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "jbuilder"
 
-  spec.add_dependency "rails", ">= 5.0.0"
+  spec.add_dependency "rails", ">= 5.0.0", "< 7.1.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -111,7 +111,10 @@ class Jbuilder::Schema
         # TODO: Find where it is being used
         _render_active_model_partial model
       else
-        _set_ref(partial || model, array: collection&.any?)
+        local = options.except(:partial, :as, :collection, :cached, :schema).first
+        as = options[:as] || ((local.is_a?(::Array) && local.size == 2 && local.first.is_a?(::Symbol) && local.last.is_a?(::Object)) ? local.first.to_s : nil)
+
+        _set_ref(as&.to_s || partial || model, array: collection&.any?)
       end
     end
 

--- a/lib/jbuilder/schema/version.rb
+++ b/lib/jbuilder/schema/version.rb
@@ -1,4 +1,4 @@
 # We can't use the standard `Jbuilder::Schema::VERSION =` because
 # `Jbuilder` isn't a regular module namespace, but a class …which also loads Active Support.
 # So we use trickery, and assign the proper version once `jbuilder/schema.rb` is loaded.
-JBUILDER_SCHEMA_VERSION = "2.3.0"
+JBUILDER_SCHEMA_VERSION = "2.3.1"


### PR DESCRIPTION
Fixes #50 by taking ref name from `as:` option or first `locals:`.