### PR TITLE
Fix: right contents for `items` in arrays

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -181,7 +181,7 @@ class Jbuilder::Schema
 
     def _nullify_non_required_types(attributes, required)
       attributes.transform_values! {
-        _1[:nullable] = true unless required.include?(attributes.key(_1))
+        _1[:type] = [_1[:type], "null"] unless required.include?(attributes.key(_1))
         _1
       }
     end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -118,6 +118,7 @@ class Jbuilder::Schema
           # as we have array of separate object partials hare, so each one of them would legally have allOf key.
           items = _scope { super(collection, *args, &block) }
           items = items[:allOf].first if items.key?(:allOf)
+          items = _object(items, _required!(items.keys)) unless items.key?(:$ref) || items.key?(:object)
           _attributes.merge! type: :array, items: items
         end
       end

--- a/lib/jbuilder/schema/version.rb
+++ b/lib/jbuilder/schema/version.rb
@@ -1,4 +1,4 @@
 # We can't use the standard `Jbuilder::Schema::VERSION =` because
 # `Jbuilder` isn't a regular module namespace, but a class …which also loads Active Support.
 # So we use trickery, and assign the proper version once `jbuilder/schema.rb` is loaded.
-JBUILDER_SCHEMA_VERSION = "2.6.0"
+JBUILDER_SCHEMA_VERSION = "2.6.1"

--- a/test/fixtures/schemas/article.yaml
+++ b/test/fixtures/schemas/article.yaml
@@ -12,9 +12,10 @@ properties:
     type: integer
     description: Article ID
   public_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Article Public ID
-    nullable: true
   title:
     type: string
     description: Article Title
@@ -38,17 +39,19 @@ properties:
     # as author is a user which is required
 #    nullable: true
   ratings:
-    type: array
+    type:
+      - array
+      - 'null'
     items:
       "$ref": "#/components/schemas/rating"
     description: Article Ratings
-    nullable: true
   comments:
-    type: array
+    type:
+      - array
+      - 'null'
     items:
       "$ref": "#/components/schemas/comment"
     description: Article Comments
-    nullable: true
 example:
   id: 1
   public_id: Article-1

--- a/test/fixtures/schemas/user.yaml
+++ b/test/fixtures/schemas/user.yaml
@@ -11,9 +11,10 @@ properties:
     type: integer
     description: User ID
   public_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: User Public ID
-    nullable: true
   name:
     type: string
     description: User Name
@@ -21,27 +22,31 @@ properties:
     type: string
     description: User Email
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
     description: User Creation Date
-    nullable: true
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
     description: User Update Date
-    nullable: true
   articles:
-    type: array
+    type:
+      - array
+      - 'null'
     items:
       "$ref": "#/components/schemas/article"
     description: User Articles
-    nullable: true
   comments:
-    type: array
+    type:
+      - array
+      - 'null'
     items:
       "$ref": "#/components/schemas/comment"
     description: User Comments
-    nullable: true
 example:
   id: 1
   public_id: User-1

--- a/test/jbuilder/schema/renderer_test.rb
+++ b/test/jbuilder/schema/renderer_test.rb
@@ -57,8 +57,14 @@ class Jbuilder::Schema::RendererTest < ActiveSupport::TestCase
       assert_equal({
         type: :array,
         items: {
-          "id" => {type: :integer},
-          "title" => {type: :string}
+          type: :object,
+          title: "Translation missing: en.title",
+          description: "Translation missing: en.description",
+          required: ["id"],
+          properties: {
+            "id" => {type: :integer},
+            "title" => {type: [:string, "null"]}
+          }
         },
         example: [
           {"id" => 1, "title" => "Generic title 0"},


### PR DESCRIPTION
Closes #51 

- Adds `type`, `title`, `description` and `properties` to array's `items`
- Reverts replacing `type: null` with `nullable` as it was done by accidentally mixing up the specifications