### PR TITLE
Fix: ActionText::RichText parsing

### DIFF
--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -292,12 +292,7 @@ class Jbuilder::Schema
     end
 
     def _value(value)
-      case value
-      when ::ActiveRecord::Base, ::ActionText::RichText
-        value.attributes
-      else
-        value
-      end
+      value.respond_to?(:attributes) ? value.attributes : value
     end
 
     def _required!(keys)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -268,7 +268,7 @@ class Jbuilder::Schema
 
     def _primitive_type(value)
       case value
-      when ::Hash, ::Struct, ::OpenStruct, ::ActiveRecord::Base, ::ActionText::RichText then :object
+      when ::Hash, ::Struct, ::OpenStruct, ::ActiveRecord::Base then :object
       when ::Array then :array
       when ::Float, ::BigDecimal then :number
       when true, false then :boolean

--- a/lib/jbuilder/schema/version.rb
+++ b/lib/jbuilder/schema/version.rb
@@ -1,4 +1,4 @@
 # We can't use the standard `Jbuilder::Schema::VERSION =` because
 # `Jbuilder` isn't a regular module namespace, but a class …which also loads Active Support.
 # So we use trickery, and assign the proper version once `jbuilder/schema.rb` is loaded.
-JBUILDER_SCHEMA_VERSION = "2.6.3"
+JBUILDER_SCHEMA_VERSION = "2.6.4"


### PR DESCRIPTION
Fixes #70 

BulletTrain apps also need to pass `ValuesTransformer` to `Jbuilder::Schema` to match API value (string instead of object).