### PR TITLE
Fix: empty types and nullable refs

### DIFF
--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "jbuilder-schema"
   spec.version = JBUILDER_SCHEMA_VERSION
   spec.authors = ["Yuri Sidorov"]
-  spec.email = ["hey@yurisidorov.com"]
+  spec.email = ["git@yurisidorov.com"]
 
   spec.summary = "Generate JSON Schema from Jbuilder files"
   spec.description = spec.summary

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -183,7 +183,7 @@ class Jbuilder::Schema
 
     def _nullify_non_required_types(attributes, required)
       attributes.transform_values! {
-        _1[:type] = [_1[:type], "null"] unless required.include?(attributes.key(_1))
+        _1[:type] = [_1[:type], "null"] if _1[:type].present? && !required.include?(attributes.key(_1))
         _1
       }
     end
@@ -200,7 +200,7 @@ class Jbuilder::Schema
       if array
         _attributes.merge! type: :array, items: ref
       else
-        _attributes.merge! allOf: [ref]
+        _attributes.merge! type: :object, allOf: [ref]
       end
     end
 

--- a/lib/jbuilder/schema/version.rb
+++ b/lib/jbuilder/schema/version.rb
@@ -1,4 +1,4 @@
 # We can't use the standard `Jbuilder::Schema::VERSION =` because
 # `Jbuilder` isn't a regular module namespace, but a class …which also loads Active Support.
 # So we use trickery, and assign the proper version once `jbuilder/schema.rb` is loaded.
-JBUILDER_SCHEMA_VERSION = "2.6.4"
+JBUILDER_SCHEMA_VERSION = "2.6.5"

--- a/test/jbuilder/schema/partials_test.rb
+++ b/test/jbuilder/schema/partials_test.rb
@@ -31,7 +31,7 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
     partial_with_inline_block = json_for(User) do |json|
       json.user { json.partial! "users/user", user: User.first }
     end
-    result = {"user" => {allOf: [{"$ref": "#/components/schemas/user"}], description: "test"}}
+    result = {"user" => {type: :object, allOf: [{"$ref": "#/components/schemas/user"}], description: "test"}}
 
     assert_equal(result, partial)
     assert_equal(result, partial_with_extra_lines)
@@ -99,7 +99,7 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
       json.author Article.first.user, partial: "api/v1/users/user", as: :user
     end
 
-    assert_equal({"author" => {allOf: [{"$ref": "#/components/schemas/user"}], description: "test"}}, result)
+    assert_equal({"author" => {type: :object, allOf: [{"$ref": "#/components/schemas/user"}], description: "test"}}, result)
   end
 
   test "block with array with partial" do


### PR DESCRIPTION
There were 2 problems this PR solves:
- There was no type for relations, but "null" was set anyway so that produced something like `type: [, "null"]`
- Type of ref relations are being set as `object`.