### PR TITLE
Feature: Add `required: true` to `schema` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,42 @@
 # Jbuilder::Schema
 
-Generate JSON Schema compatible with OpenAPI 3 specs from Jbuilder files
+Easily Generate JSON Schemas from Jbuilder Templates for OpenAPI 3.1
 
-## Installation
+## Quick Start
 
-In your Gemfile, put `gem "jbuilder-schema"` after Jbuilder:
+### Installation
+
+Add this to your Gemfile:
 
     gem "jbuilder"
     gem "jbuilder-schema"
 
-And run:
+Then, run `bundle` or install it manually using `gem install jbuilder-schema`.
 
-    $ bundle
+### Generating Schemas
 
-Or install it yourself as:
-
-    $ gem install jbuilder-schema
-
-## Usage
-
-Wherever you want to generate schemas, call `Jbuilder::Schema.yaml` or `Jbuilder::Schema.json`:
+Use `Jbuilder::Schema.yaml` or `Jbuilder::Schema.json` to create schemas. For example:
 
 ```ruby
 Jbuilder::Schema.yaml(@article, title: 'Article', description: 'Article in the blog', locals: { current_user: @user })
 ```
 
-Under the hood `Jbuilder::Schema.yaml`/`json` will use Action View's `render` method and support the same arguments.
+This will render a Jbuilder template (e.g., `articles/_article.json.jbuilder`) and make `@article` available in the partial. You can also pass additional locals.
 
-So in the above example, the `@article`'s `to_partial_path` path is used to find and render a `articles/_article.json.jbuilder` template, and `article` is available in the partial.
+### Advanced Usage
 
-Additionally, we can pass any needed `locals:`.
+#### Rendering Specific Directories
 
-The `title` and `description` set the title and description of the schema — though they can also come from locale files (see *[Titles & Descriptions](#titles--descriptions)*);
-
-### Use with a directory within app/views
-
-If you have a directory within app/views where your Jbuilder templates are, you can use `renderer` to capture that along with any `locals:` common to the templates you'll render:
+If your Jbuilder templates are in a specific directory, use `Jbuilder::Schema.renderer`:
 
 ```ruby
 jbuilder = Jbuilder::Schema.renderer('app/views/api/v1', locals: { current_user: @user })
 jbuilder.yaml @article, title: 'Article', description: 'Article in the blog'
 ```
 
-This means you don't have to write out the partial path, which gets tedious with multiple schema renders:
+#### Rendering Templates
 
-```ruby
-Jbuilder::Schema.yaml(partial: 'api/v1/articles/article', locals: { article: @article, current_user: @user }, title: 'Article', description: 'Article in the blog')
-```
-
-### Rendering a template
-
-If you're rendering a template like `app/views/articles/index.jbuilder`:
-
-```ruby
-json.articles @articles, :id, :title
-```
-
-You'll need to pass the relative template path in `template:` and any needed instance variables in `assigns:` like so:
+For templates like `app/views/articles/index.jbuilder`, specify the template path and variables:
 
 ```ruby
 Jbuilder::Schema.yaml(template: "articles/index", assigns: { articles: Article.first(3) })
@@ -64,7 +44,7 @@ Jbuilder::Schema.yaml(template: "articles/index", assigns: { articles: Article.f
 
 ### Output
 
-Jbuilder::Schema automatically sets `description`, `type`, and `required` options in JSON-Schema.
+Jbuilder::Schema automatically sets `description`, `type`, and `required` fields in the JSON Schema. You can *[customize](#customization)* these using the `schema:` hash.
 
 For example, if we have a `_article.json.jbuilder` file:
 
@@ -141,6 +121,17 @@ You can customize output for multiple fields at once:
 
 ```ruby
 json.extract! user, :id, :name, :email, schema: {id: {type: :string}, email: {type: :email, pattern: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/}}
+```
+
+#### Required
+
+To add a property to `required` array, pass `schema: {required: true}` to it:
+
+```ruby
+json.title article.name, schema: {required: true}
+json.author schema: {required: true} do
+  json.extract! article.user
+end
 ```
 
 ### Nested objects

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Jbuilder::Schema.yaml(@article, title: 'Article', description: 'Article in the b
 
 This will render a Jbuilder template (e.g., `articles/_article.json.jbuilder`) and make `@article` available in the partial. You can also pass additional locals.
 
+### Contents
+
+- [Advanced Usage](#advanced-usage)
+    - [Rendering Specific Directories](#rendering-specific-directories)
+    - [Rendering Templates](#rendering-templates)
+- [Output](#output)
+- [Handling Arrays and Objects](#handling-arrays-and-objects)
+- [Nested Partials and Arrays](#nested-partials-and-arrays)
+- [Customization](#customization)
+    - [Titles & Descriptions](#titles--descriptions)
+- [Configuration](#configuration)
+- [Integration with RSwag](#integration-with-rswag)
+- [Contributing](#contributing)
+- [License](#license)
+- [Sponsor](#open-source-development-sponsored-by)
+
 ### Advanced Usage
 
 #### Rendering Specific Directories
@@ -90,7 +106,7 @@ Support of various object types like `Hash`, `Struct`, `OpenStruct`, and `Active
 #### Example
 
 ```ruby
-json.custom_array [1, article.user, 2, "Text", [3.14, 25.44], 5.33, [4, "Another text", {z: 7, x: "SDR"}], {a: 1, b: "Test"}, {c: 2, d: {z: 3, x: "b"}}]
+json.custom_array [1, article.user, 2, "Text", [3.14, 25.44], 5.33, [3, "Another text", {a: 4, b: "One more text"}], {c: 5, d: "And another"}, {e: 6, f: {g: 7, h: "Last Text"}}]
 ```
 
 #### Result
@@ -117,29 +133,34 @@ properties:
               - type: integer
               - type: string
               - type: object
-                # ... object properties ...
+                properties:
+                  a:
+                    type: integer
+                    # ... description ...
+                  b:
+                    type: integer
+                    # ... description ...
         - type: number
-        # ... additional types ...
-        - type: object
-          properties:
-            a:
-              type: integer
-              # ... description ...
-            b:
-              type: integer
-              # ... description ...
         - type: object
           properties:
             c:
               type: integer
               # ... description ...
             d:
+              type: integer
+              # ... description ...
+        - type: object
+          properties:
+            e:
+              type: integer
+              # ... description ...
+            f:
               type: object
               properties:
-                z:
+                h:
                   type: integer
                   # ... description ...
-                x:
+                g:
                   type: string
                   # ... description ...
 ```
@@ -253,7 +274,7 @@ properties:
         description: User Email
 ```
 
-### Titles & Descriptions
+#### Titles & Descriptions
 
 Set custom titles and descriptions directly or through locale files. For models, use `<underscored_plural_model_name>.<title_name>` and for fields, use `<underscored_plural_model_name>.fields.<field_name>.<description_name>` in locale files:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Jbuilder::Schema.yaml(@article, title: 'Article', description: 'Article in the b
 
 This will render a Jbuilder template (e.g., `articles/_article.json.jbuilder`) and make `@article` available in the partial. You can also pass additional locals.
 
-### Contents
+## Contents
 
 - [Advanced Usage](#advanced-usage)
     - [Rendering Specific Directories](#rendering-specific-directories)
@@ -101,7 +101,7 @@ properties:
 
 The gem efficiently handles arrays and objects, including nested structures. Arrays with a single element type are straightforwardly represented, while arrays with mixed types use the `anyOf` keyword for versatility.
 
-Support of various object types like `Hash`, `Struct`, `OpenStruct`, and `ActiveRecord::Base` is also integrated. It simplifies object schemas by setting only type and properties.
+Support of various object types like `Hash`, `Struct`, `OpenStruct`, and `ActiveRecord::Base` is also integrated. It simplifies object schemas by setting only `type` and `properties`.
 
 #### Example
 
@@ -163,6 +163,7 @@ properties:
                 g:
                   type: string
                   # ... description ...
+    description: Very weird custom array
 ```
 
 Each schema is unique, ensuring no duplication. Description fields are nested under parent field names for clarity.
@@ -181,6 +182,12 @@ end
 json.comments do
   json.array! article.comments, partial: "api/v1/articles/comments/comment", as: :article_comment
 end
+json.ratings do
+    json.array! article.ratings, schema: {object: article.ratings.first, title: "Rating", description: "Article Rating"} do |rating|
+      json.partial! "api/v1/shared/id", resource: rating
+      json.extract! rating, :value
+    end
+end
 ```
 
 #### Result
@@ -197,10 +204,32 @@ properties:
     type: array
     items:
       - "$ref": "#/components/schemas/Comment"
-    description: Comment
+    description: Comments
+  ratings:
+    type: array
+    items:
+      type: object
+      title: Rating
+      description: Article Rating
+      required:
+        - id
+        - value
+      properties:
+        id:
+          type: integer
+          description: Rating ID
+        public_id:
+          type:
+            - string
+            - "null"
+          description: Rating Public ID
+        value:
+          type: integer
+          description: Rating Value
+    description: Article Ratings
 ```
 
-Reference name is taken from `:as` option or first of the `locals:`.
+Reference names are taken from `:as` option or first of the `locals:`.
 
 The path to component schemas can be configured with `components_path` variable, which defaults to `components/schemas`. See *[Configuration](#configuration)* for more info.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,43 @@ properties:
 
 Each schema is unique, ensuring no duplication. Description fields are nested under parent field names for clarity.
 
+### Nested Partials and Arrays
+
+Nested partials and arrays will most commonly produce reference to the related schema component.
+Only if block with partial includes other fields, the inline object will be generated.
+
+#### Example
+
+```ruby
+json.author do
+  json.partial! "api/v1/users/user", user: article.user
+end
+json.comments do
+  json.array! article.comments, partial: "api/v1/articles/comments/comment", as: :article_comment
+end
+```
+
+#### Result
+
+```yaml
+# ... object description ...
+properties:
+  author:
+    type: object
+    allOf:
+      - "$ref": "#/components/schemas/User"
+    description: User
+  comments:
+    type: array
+    items:
+      - "$ref": "#/components/schemas/Comment"
+    description: Comment
+```
+
+Reference name is taken from `:as` option or first of the `locals:`.
+
+The path to component schemas can be configured with `components_path` variable, which defaults to `components/schemas`. See *[Configuration](#configuration)* for more info.
+
 ### Customization
 
 Customize individual or multiple fields at once using the `schema:` attribute.
@@ -215,43 +252,6 @@ properties:
         pattern: "^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$"
         description: User Email
 ```
-
-### Nested Partials and Arrays
-
-Nested partials and arrays will most commonly produce reference to the related schema component.
-Only if block with partial includes other fields, the inline object will be generated.
-
-#### Example
-
-```ruby
-json.author do
-  json.partial! "api/v1/users/user", user: article.user
-end
-json.comments do
-  json.array! article.comments, partial: "api/v1/articles/comments/comment", as: :article_comment
-end
-```
-
-#### Result
-
-```yaml
-# ... object description ...
-properties:
-  author:
-    type: object
-    allOf:
-      - "$ref": "#/components/schemas/User"
-    description: User
-  comments:
-    type: array
-    items:
-      - "$ref": "#/components/schemas/Comment"
-    description: Comment
-```
-
-Reference name is taken from `:as` option or first of the `locals:`.
-
-The path to component schemas can be configured with `components_path` variable, which defaults to `components/schemas`. See *[Configuration](#configuration)* for more info.
 
 ### Titles & Descriptions
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -37,7 +37,11 @@ class Jbuilder::Schema
         super || translate(Jbuilder::Schema.description_name)
       end
 
-      def translate_field(key)
+      def translate_title(key)
+        translate("fields.#{key}.#{Jbuilder::Schema.title_name}")
+      end
+
+      def translate_description(key)
         translate("fields.#{key}.#{Jbuilder::Schema.description_name}")
       end
 
@@ -86,6 +90,9 @@ class Jbuilder::Schema
       old_configuration, @configuration = @configuration, Configuration.build(**schema) if schema&.dig(:object)
       _required << key if schema&.delete(:required) == true
       @within_block = _within_block?(&block)
+
+
+      ::Rails.logger.debug(">>>SESESE #{schema}")
 
       _with_schema_overrides(key => schema) do
         keys = args.presence || _extract_possible_keys(value)
@@ -190,8 +197,9 @@ class Jbuilder::Schema
     end
 
     def _set_description(key, value)
-      if !value.key?(:description) && @configuration.object
-        value[:description] = @configuration.translate_field(key)
+      if @schema_overrides.try(:dig, key) || @configuration.object
+        value[:title] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) || @configuration.translate_title(key)
+        value[:description] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :description) || @configuration.translate_description(key)
       end
     end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -91,9 +91,6 @@ class Jbuilder::Schema
       _required << key if schema&.delete(:required) == true
       @within_block = _within_block?(&block)
 
-
-      ::Rails.logger.debug(">>>SESESE #{schema}")
-
       _with_schema_overrides(key => schema) do
         keys = args.presence || _extract_possible_keys(value)
 
@@ -198,7 +195,7 @@ class Jbuilder::Schema
 
     def _set_description(key, value)
       if @schema_overrides.try(:dig, key) || @configuration.object
-        value[:title] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) || @configuration.translate_title(key)
+        value[:title] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) if @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) # || @configuration.translate_title(key)
         value[:description] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :description) || @configuration.translate_description(key)
       end
     end

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -84,10 +84,8 @@ class Jbuilder::Schema
 
     def set!(key, value = BLANK, *args, schema: nil, **options, &block)
       old_configuration, @configuration = @configuration, Configuration.build(**schema) if schema&.dig(:object)
-
+      _required << key if schema&.delete(:required) == true
       @within_block = _within_block?(&block)
-
-      _required << key if schema&.delete(:required)
 
       _with_schema_overrides(key => schema) do
         keys = args.presence || _extract_possible_keys(value)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -194,10 +194,11 @@ class Jbuilder::Schema
     end
 
     def _set_description(key, value)
-      if @schema_overrides.try(:dig, key) || @configuration.object
-        value[:title] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) if @schema_overrides.try(:dig, key)&.to_h.try(:[], :title) # || @configuration.translate_title(key)
-        value[:description] ||= @schema_overrides.try(:dig, key)&.to_h.try(:[], :description) || @configuration.translate_description(key)
-      end
+      overrides = @schema_overrides&.dig(key)&.to_h || {}
+      return unless overrides.any? || @configuration.object
+
+      value[:title] ||= overrides[:title] if overrides&.key?(:title)
+      value[:description] ||= overrides[:description] || @configuration.translate_description(key)
     end
 
     def _set_ref(object, **options)

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -24,9 +24,9 @@ class Jbuilder::Schema
       end
     end
 
-    class Configuration < ::Struct.new(:object, :title, :description, keyword_init: true)
-      def self.build(object: nil, object_title: nil, object_description: nil, **)
-        new(object: object, title: object_title, description: object_description)
+    class Configuration < ::Struct.new(:object, :title, :description, :required, keyword_init: true)
+      def self.build(object: nil, object_title: nil, object_description: nil, object_required: false, **)
+        new(object: object, title: object_title, description: object_description, required: object_required)
       end
 
       def title
@@ -84,6 +84,9 @@ class Jbuilder::Schema
 
     def set!(key, value = BLANK, *args, schema: nil, **options, &block)
       old_configuration, @configuration = @configuration, Configuration.build(**schema) if schema&.dig(:object)
+
+      ::Rails.logger.debug(">>>@configuration #{@configuration}")
+
       @within_block = _within_block?(&block)
 
       _with_schema_overrides(key => schema) do

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -193,7 +193,7 @@ class Jbuilder::Schema
       }
     end
 
-    def _set_description(key, value)
+    def _set_title_and_description(key, value)
       overrides = @schema_overrides&.dig(key)&.to_h || {}
       return unless overrides.any? || @configuration.object
 
@@ -259,7 +259,7 @@ class Jbuilder::Schema
         options[:enum] = defined_enum.keys
       end
 
-      _set_description key, options unless within_array
+      _set_title_and_description key, options unless within_array
       options
     end
 
@@ -292,7 +292,7 @@ class Jbuilder::Schema
     def _set_value(key, value)
       value = _value(value)
       value = _schema(key, value) unless value.is_a?(::Hash) && (value.key?(:type) || value.key?(:allOf)) # rubocop:disable Style/UnlessLogicalOperators
-      _set_description(key, value)
+      _set_title_and_description(key, value)
       super
     end
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -83,7 +83,6 @@ class Jbuilder::Schema
     end
 
     def set!(key, value = BLANK, *args, schema: nil, **options, &block)
-      ::Rails.logger.debug(">>>set! #{key}")
       old_configuration, @configuration = @configuration, Configuration.build(**schema) if schema&.dig(:object)
 
       # ::Rails.logger.debug(">>>@configuration #{@configuration}")

--- a/lib/jbuilder/schema/version.rb
+++ b/lib/jbuilder/schema/version.rb
@@ -1,4 +1,4 @@
 # We can't use the standard `Jbuilder::Schema::VERSION =` because
 # `Jbuilder` isn't a regular module namespace, but a class …which also loads Active Support.
 # So we use trickery, and assign the proper version once `jbuilder/schema.rb` is loaded.
-JBUILDER_SCHEMA_VERSION = "2.6.7"
+JBUILDER_SCHEMA_VERSION = "2.6.8"

--- a/test/jbuilder/schema/partials_test.rb
+++ b/test/jbuilder/schema/partials_test.rb
@@ -104,12 +104,12 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
 
   test "block with array with partial" do
     result = json_for(Article) do |json|
-      json.articles schema: {object: Article.first} do
+      json.articles schema: {object: Article.first, description: "Articles"} do
         json.array! Article.all, partial: "api/v1/articles/article", as: :article
       end
     end
 
-    assert_equal({"articles" => {type: :array, items: {"$ref": "#/components/schemas/article"}, description: "test"}}, result)
+    assert_equal({"articles" => {type: :array, items: {"$ref": "#/components/schemas/article"}, description: "Articles"}}, result)
   end
 
   test "one-line text is defined correctly" do
@@ -140,7 +140,7 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
       json.articles { ;   ;#comment;    #another comment; json.partial! 'api/v1/articles/article', article: user.article }
     JBUILDER
     many_lines = <<~JBUILDER
-      json.articles do
+      json.articles schema: {required: true} do
         json.partial! 'api/v1/articles/article', article: user.article
         json.comments_count user.article.comments.count
       end

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -100,7 +100,7 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
       end
     end
 
-    assert_equal({"user" => {type: :object, title: "test", description: "test", required: %w[id full_name], properties: {"id" => {type: :integer, description: "test"}, full_name: {type: :string, description: "test"}}}}, result)
+    assert_equal({"user" => {type: :object, title: "test", description: "test", required: %w[id full_name], properties: {"id" => {type: :integer, description: "test"}, "full_name" => {type: :string, description: "test"}}}}, result)
   end
 
   test "object with schema required attribute" do
@@ -117,13 +117,12 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
   end
 
   test "array with schema required attribute" do
-    user = Comment.first.user
-    articles = user.articles
+    user = Comment.last.user
     result = json_for(Comment) do |json|
       json.author schema: {object: user} do
         json.name Comment.first.user.name
         json.posts schema: {required: true} do |post|
-          json.array! Article.all, partial: "api/v1/articles/article", as: :article
+          json.array! user.articles, partial: "api/v1/articles/article", as: :article
         end
       end
     end

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -77,8 +77,6 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
   end
 
   test "object without schema attributes" do
-    # TODO: This also should probably include :name as required
-    # https://github.com/bullet-train-co/jbuilder-schema/issues/65
     result = json_for(Article) do |json|
       json.user User.first, :id, :name, :created_at
     end
@@ -92,6 +90,17 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
     end
 
     assert_equal({"user" => {type: :object, title: "User", description: "User writes articles", required: %w[id name], properties: {"id" => {type: :integer, description: "test"}, "name" => {type: :string, description: "test"}, "created_at" => {type: [:string, "null"], format: "date-time", description: "test"}}}}, result)
+  end
+
+  test "field with schema required attribute" do
+    result = json_for(Article) do |json|
+      json.user do |user|
+        user.id User.first.id
+        user.full_name User.first.name, schema: {required: true}
+      end
+    end
+
+    assert_equal({"user" => {type: :object, title: "test", description: "test", required: %w[id full_name], properties: {"id" => {type: :integer, description: "test"}, "full_name" => {type: :string, description: "test"}}}}, result)
   end
 
   test "simple block" do

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -116,6 +116,21 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
     assert_equal({"article" => {type: :object, title: "test", description: "test", required: %w[title author], properties: {"title" => {type: :string, description: "test"}, "author" => {type: :object, allOf: [{:$ref => "#/components/schemas/user"}], description: "test"}}}}, result)
   end
 
+  test "array with schema required attribute" do
+    user = Comment.first.user
+    articles = user.articles
+    result = json_for(Comment) do |json|
+      json.author schema: {object: user} do
+        json.name Comment.first.user.name
+        json.posts schema: {required: true} do |post|
+          json.array! Article.all, partial: "api/v1/articles/article", as: :article
+        end
+      end
+    end
+
+    assert_equal({"author" => {type: :object, title: "test", description: "test", required: %w[name posts], properties: {"name" => {type: :string, description: "test"}, "posts" => {type: :array, items: {:$ref => "#/components/schemas/article"}, description: "test"}}}}, result)
+  end
+
   test "simple block" do
     result = json_for(User) do |json|
       json.author { json.id 123 }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,4 @@ ActiveSupport.test_order = :random
 ActiveSupport::TestCase.file_fixture_path = "test/fixtures"
 
 # In debug mode uncomment this string to have ::Rails.logger available
-# ::Rails.logger = ::Logger.new($stdout)
+::Rails.logger = ::Logger.new($stdout)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,4 @@ ActiveSupport.test_order = :random
 ActiveSupport::TestCase.file_fixture_path = "test/fixtures"
 
 # In debug mode uncomment this string to have ::Rails.logger available
-::Rails.logger = ::Logger.new($stdout)
+# ::Rails.logger = ::Logger.new($stdout)


### PR DESCRIPTION
Fixes #65 
Fixes #78
Fixes #81 
Closes #55 

**New option added to `schema`: `required`.**

For example, if `team.name` should be required, but in Jbuilder it is written as `title`:
```
json.title team.name
```
we need to add `schema: {required: true}` to add this field to the `required` array:
```
json.title team.name, schema: {required: true}
```
That is also true for nested partials and arrays:
```
json.organization schema: {required: true} do
  json.partial! "api/v1/teams/team", team: project.team
end

json.project_goals project.goals, schema: {required: true} do |goal|
  json.partial! "api/v1/goals/goal", goal: goal
end
```

**`required` should be set explicitly to `true`, any other value would be ignored.**

This PR also fixes several other minor bugs.