### PR TITLE
[CI] Allow CI workflow to be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: tmp/starter/yarn.lock
 
+      - name: Allow adding of this gem
+        run: bundle config unset deployment
+        working-directory: tmp/starter
+
       - name: Link This Repo
         uses: bullet-train-co/link-local-gem@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-
   pull_request:
 
 jobs:


### PR DESCRIPTION
This is mainly helpful since the workflow depends on some other bullet-train actions. After updating those actions it can be useful to trigger a build in this repo (and others) to make sure that they still work correctly.