### PR TITLE
Fallback api translation keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - "6.1"
           - "main"
         ruby-version:
-          - "3.0"
+          - "3.1"
           - "3.2"
 
     env:
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.1"
           bundler-cache: true
       - name: Run Standard
         run: bundle exec rake standard

--- a/README.md
+++ b/README.md
@@ -321,13 +321,17 @@ en:
 
 Configure Jbuilder::Schema in `config/initializers/jbuilder_schema.rb`:
 
+The `title_name` and `description_name` parameters can accept either a single string or an array of strings. This feature provides the flexibility to specify fallback keys.
+
 ```ruby
 Jbuilder::Schema.configure do |config|
-  config.components_path = "components/schemas"   # could be "definitions/schemas"
-  config.title_name = "title"                     # could be "label"
-  config.description_name = "description"         # could be "heading"
+  config.components_path = "components/schemas"                   # could be "definitions/schemas"
+  config.title_name = "title"                                     # could be "label"
+  config.description_name = ["api_description", "description"]    # could be "heading"
 end
 ```
+
+With this configuration, the system will first try to find a translation for <underscored_plural_model_name>.fields.<field_name>.api_description. If it doesn't find a translation for this key, it will then attempt to find a translation for <underscored_plural_model_name>.fields.<field_name>.description.
 
 ### Integration with RSwag
 

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -52,7 +52,7 @@ class Jbuilder::Schema
           translation = I18n.t(key, scope: @scope ||= object&.class&.name&.underscore&.pluralize, default: nil)
           return translation if translation.present?
         end
-        nil
+        I18n.t(keys.first, scope: @scope ||= object&.class&.name&.underscore&.pluralize)
       end
 
       def title_keys
@@ -209,10 +209,8 @@ class Jbuilder::Schema
       overrides = @schema_overrides&.dig(key)&.to_h || {}
       return unless overrides.any? || @configuration.object
 
-      title = overrides[:title] || @configuration.translate_title(key)
-      description = overrides[:description] || @configuration.translate_description(key)
-      value[:title] ||= title if title
-      value[:description] ||= description if description
+      value[:title] ||= overrides[:title] if overrides&.key?(:title)
+      value[:description] ||= overrides[:description] || @configuration.translate_description(key)
     end
 
     def _set_ref(object, **options)

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -59,7 +59,7 @@ class Article < ActiveRecord::Base
   has_many :ratings
   has_many :comments
 
-  enum status: %w[pending published archived].index_by(&:itself)
+  enum :status, %w[pending published archived].index_with(&:itself)
 
   validates_presence_of :user, :status, :title, :body
 end

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -59,7 +59,7 @@ class Article < ActiveRecord::Base
   has_many :ratings
   has_many :comments
 
-  enum :status, %w[pending published archived].index_with(&:itself)
+  enum status: %w[pending published archived].index_by(&:itself)
 
   validates_presence_of :user, :status, :title, :body
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ require "bundler/setup"
 
 require "rails"
 
+require "active_support"
+require "active_support/core_ext/module/attr_internal"
+
 require "jbuilder"
 Jbuilder::Railtie.run_initializers
 


### PR DESCRIPTION
This allows for having fallbacks for the `api_title` and `api_description` configuration settings.

This lets us progressively add improved api documentation without having to add the new keys to every single translation file upfront.