### PR TITLE
fix test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails-version:
-          - "7.1"
-          - "6.1"
-          - "main"
-        ruby-version:
-          - "3.1"
-          - "3.2"
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        rails-version: ["6.0", "6.1", "7.0", "7.1", "7.2", "8.0", "main"]
+        exclude:
+          # Rails 7.2 requires Ruby >= 3.1
+          - { ruby-version: "2.7", rails-version: "7.2" }
+          - { ruby-version: "3.0", rails-version: "7.2" }
+
+          # Rails 8.0 requires Ruby >= 3.2
+          - { ruby-version: "2.7", rails-version: "8.0" }
+          - { ruby-version: "3.0", rails-version: "8.0" }
+          - { ruby-version: "3.1", rails-version: "8.0" }
+
+          # Rails main requires Ruby >= 3.2
+          - { ruby-version: "2.7", rails-version: "main" }
+          - { ruby-version: "3.0", rails-version: "main" }
+          - { ruby-version: "3.1", rails-version: "main" }
+
+          # Ruby >= 3.4 requires Rails >= 7.1
+          - { ruby-version: "3.4", rails-version: "6.0" }
+          - { ruby-version: "3.4", rails-version: "6.1" }
+          - { ruby-version: "3.4", rails-version: "7.0" }
 
     env:
       RAILS_ENV: test
@@ -28,20 +42,20 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake test
+      - uses: actions/checkout@v5
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
 
   standard:
     runs-on: ubuntu-latest
     name: "Standard"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -50,16 +64,28 @@ jobs:
       - name: Run Standard
         run: bundle exec rake standard
 
-  starter_repo:
+  calculate_matrix:
+    name: 🧮 Calculate Dynamic Matrix
     runs-on: ubuntu-latest
-    name: Bullet Train Starter Repo Minitest
+    outputs:
+      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
+      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
+      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+    steps:
+      - id: dynamic-matrix
+        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+        with:
+          numberOfTestNodes: 4
+
+  starter_repo:
+    # Don't run against starter_repo if test, standard, or calculate_matrix fail
+    needs: [test, standard, calculate_matrix]
+    runs-on: ubuntu-latest
+    name: Bullet Train Starter Repo Tests
     strategy:
       fail-fast: false
       matrix:
-        # Set identifiers for parallel jobs. These can be anything.
-        # For instance if you want a Three Amigos themed pipeline you could use:
-        # ci_node_index: [Dusty, Ned, Lucky]
-        ci_node_index: [1,2,3,4]
+        parallel_test_groups: ${{ fromJson(needs.calculate_matrix.outputs.matrix) }}
     services:
       postgres:
         image: postgres:11-alpine
@@ -87,12 +113,13 @@ jobs:
           --health-retries 5
     env:
       RAILS_ENV: test
-      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      POSTGRES_USER: rails
+      POSTGRES_PASSWORD: password
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
     steps:
       - name: Checkout This Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
@@ -112,11 +139,14 @@ jobs:
           working-directory: tmp/starter
           bundler-cache: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: tmp/starter/.nvmrc
-          cache: 'yarn'
+          cache: "yarn"
           cache-dependency-path: tmp/starter/yarn.lock
 
       - name: Allow adding of this gem
@@ -135,28 +165,33 @@ jobs:
           application_dir: tmp/starter
           core_dir: tmp/core
 
-      - name: Set up database schema
-        run: bin/rails db:schema:load
-        working-directory: ./tmp/starter
+      - name: Set up parallel_tests
+        run: bin/rake parallel:setup[${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}]
+        working-directory: tmp/starter
+
+      - name: Touch parallel_tests runtime log
+        run: touch tmp/parallel_runtime_test.log
+        working-directory: tmp/starter
 
       - name: Run Tests
         id: run-tests
         env:
-          # Specifies how many jobs you would like to run in parallel,
-          # used for partitioning
-          CI_NODE_TOTAL: ${{ strategy.job-total }}
-          # Use the index from matrix as an environment variable
-          CI_NODE_INDEX: ${{ strategy.job-index }}
+          AUTH_ENDPOINT: https://no-site.nowhere
+          AWS_REGION: us-east-1
+          PARALLEL_TESTS_RECORD_RUNTIME: true
         continue-on-error: false
-        run : bin/parallel-ci
-        working-directory: ./tmp/starter
+        run: |
+          bundle exec parallel_test test \
+            -n ${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }} \
+            --only-group ${{ matrix.parallel_test_groups }} \
+            --group-by runtime \
+            --allowed-missing 100 \
+            --verbose \
+            --verbose-command
+        working-directory: tmp/starter
 
       - name: Test Summary
         uses: test-summary/action@v2
         with:
           paths: "tmp/starter/test/reports/**/TEST-*.xml"
-          #output: test-summary.md
         if: always()
-
-
-

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,25 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-
-gem "sqlite3"
-
 gem "standard", "~> 1.3"
-
 gem "mocha"
 
 rails_version = ENV.fetch("RAILS_VERSION", "7.0")
 
-rails_constraint = if rails_version == "main"
-  {github: "rails/rails"}
+# SQLite3 version constraint for Rails 7.1+ and Ruby 3.1+
+sqlite3_version = if (rails_version == "main" || Gem::Version.new(rails_version) >= Gem::Version.new("7.1") && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1"))
+  "~> 2.1"
 else
-  "~> #{rails_version}.0"
+  "~> 1.4"
 end
+
+gem "sqlite3", sqlite3_version
+
+rails_constraint =
+  if rails_version == "main"
+    { github: "rails/rails" }
+  else
+    "~> #{rails_version}.0"
+  end
 
 gem "rails", rails_constraint

--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary
   spec.homepage = "https://github.com/bullet-train-co/jbuilder-schema"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "jbuilder"
-  spec.add_dependency "rails", ">= 5.0.0"
+  spec.add_dependency "rails", ">= 6.0"
   spec.add_dependency "method_source"
   spec.add_dependency "ostruct"
   spec.add_dependency "bigdecimal"

--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -22,9 +22,11 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ Gemfile .gitignore test/ .github/ .standard.yml])
     end
   end
   spec.bindir = "exe"

--- a/jbuilder-schema.gemspec
+++ b/jbuilder-schema.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jbuilder"
   spec.add_dependency "rails", ">= 5.0.0"
   spec.add_dependency "method_source"
+  spec.add_dependency "ostruct"
+  spec.add_dependency "bigdecimal"
+  spec.add_dependency "logger"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/jbuilder/schema/template.rb
+++ b/lib/jbuilder/schema/template.rb
@@ -3,6 +3,7 @@
 require "jbuilder/jbuilder_template"
 require "active_support/inflections"
 require "method_source"
+require "ostruct"
 
 class Jbuilder::Schema
   class Template < ::JbuilderTemplate

--- a/test/fixtures/app/views/api/v1/ratings/_rating.json.jbuilder
+++ b/test/fixtures/app/views/api/v1/ratings/_rating.json.jbuilder
@@ -4,7 +4,8 @@ json.partial! "api/v1/ratings/value", rating: rating
 json.author rating.user, partial: "api/v1/users/name", as: :user
 
 # Object with many meaningful lines — should be array with object schemas
-json.comments schema: {object: rating.article.comments.first} do
-  json.partial! "api/v1/articles/comments/text", comment: rating.article.comments.first
+json.comments [rating.article.comments.first], schema: { object: rating.article.comments.first } do |comment|
+  json.partial! "api/v1/articles/comments/text", comment: comment
   json.count rating.article.comments.count
 end
+

--- a/test/fixtures/schemas/article.yaml
+++ b/test/fixtures/schemas/article.yaml
@@ -30,14 +30,14 @@ properties:
     type: string
     pattern: "\\w+"
     description: Article Body
-#    TODO: Partial with no arguments produces wrong schema ref (#/components/schemas/resource here)
-#  author:
-#    allOf:
-#      - "$ref": "#/components/schemas/user"
-#    description: Article Author
-    # TODO: nullable: true should not be here https://github.com/bullet-train-co/jbuilder-schema/issues/65
-    # as author is a user which is required
-#    nullable: true
+  # TODO: Partial with no arguments produces wrong schema ref (#/components/schemas/resource here)
+  # author:
+  #   allOf:
+  #     - "$ref": "#/components/schemas/user"
+  #   description: Article Author
+  #   TODO: nullable: true should not be here https://github.com/bullet-train-co/jbuilder-schema/issues/65
+  #   as author is a user which is required
+  # nullable: true
   ratings:
     type:
       - array
@@ -58,32 +58,32 @@ example:
   title: Generic title 0
   status: pending
   body: Lorem ipsum… 0
-#  author:
-#    id: 1
-#    public_id: User-1
-#    name: Generic name 0
-#    email: user-0@example.com
-#    created_at: '2023-01-01T12:00:00.000Z'
-#    updated_at: '2023-01-01T12:00:00.000Z'
+  # author:
+  #   id: 1
+  #   public_id: User-1
+  #   name: Generic name 0
+  #   email: user-0@example.com
+  #   created_at: '2023-01-01T12:00:00.000Z'
+  #   updated_at: '2023-01-01T12:00:00.000Z'
   ratings:
     - value: 5
       author:
         name: Generic name 0
       comments:
-        text: Lorem ipsum… 0
-        count: 3
+        - text: Lorem ipsum… 0
+          count: 3
     - value: 4
       author:
         name: Generic name 1
       comments:
-        text: Lorem ipsum… 0
-        count: 3
+        - text: Lorem ipsum… 0
+          count: 3
     - value: 3
       author:
         name: Generic name 2
       comments:
-        text: Lorem ipsum… 0
-        count: 3
+        - text: Lorem ipsum… 0
+          count: 3
   comments:
     - text: Lorem ipsum… 0
       author:

--- a/test/fixtures/schemas/user.yaml
+++ b/test/fixtures/schemas/user.yaml
@@ -13,7 +13,7 @@ properties:
   public_id:
     type:
       - string
-      - 'null'
+      - "null"
     description: User Public ID
   name:
     type: string
@@ -24,26 +24,26 @@ properties:
   created_at:
     type:
       - string
-      - 'null'
+      - "null"
     format: date-time
     description: User Creation Date
   updated_at:
     type:
       - string
-      - 'null'
+      - "null"
     format: date-time
     description: User Update Date
   articles:
     type:
       - array
-      - 'null'
+      - "null"
     items:
       "$ref": "#/components/schemas/article"
     description: User Articles
   comments:
     type:
       - array
-      - 'null'
+      - "null"
     items:
       "$ref": "#/components/schemas/comment"
     description: User Comments
@@ -52,8 +52,8 @@ example:
   public_id: User-1
   name: Generic name 0
   email: user-0@example.com
-  created_at: '2023-01-01T12:00:00.000Z'
-  updated_at: '2023-01-01T12:00:00.000Z'
+  created_at: "2023-01-01T12:00:00.000Z"
+  updated_at: "2023-01-01T12:00:00.000Z"
   articles:
     - id: 1
       public_id: Article-1
@@ -65,20 +65,20 @@ example:
           author:
             name: Generic name 0
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 4
           author:
             name: Generic name 1
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 3
           author:
             name: Generic name 2
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
       comments:
         - text: Lorem ipsum… 0
           author:
@@ -120,20 +120,20 @@ example:
           author:
             name: Generic name 0
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 4
           author:
             name: Generic name 1
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 3
           author:
             name: Generic name 2
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
       comments:
         - text: Lorem ipsum… 0
           author:
@@ -175,51 +175,51 @@ example:
           author:
             name: Generic name 0
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 4
           author:
             name: Generic name 1
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
         - value: 3
           author:
             name: Generic name 2
           comments:
-            text: Lorem ipsum… 0
-            count: 3
+            - text: Lorem ipsum… 0
+              count: 3
       comments:
         - text: Lorem ipsum… 0
           author:
             name: Generic name 2
           ratings:
-          - value: 5
-            count: 3
-          - value: 4
-            count: 3
-          - value: 3
-            count: 3
+            - value: 5
+              count: 3
+            - value: 4
+              count: 3
+            - value: 3
+              count: 3
         - text: Lorem ipsum… 1
           author:
             name: Generic name 1
           ratings:
-          - value: 5
-            count: 3
-          - value: 4
-            count: 3
-          - value: 3
-            count: 3
+            - value: 5
+              count: 3
+            - value: 4
+              count: 3
+            - value: 3
+              count: 3
         - text: Lorem ipsum… 2
           author:
             name: Generic name 0
           ratings:
-          - value: 5
-            count: 3
-          - value: 4
-            count: 3
-          - value: 3
-            count: 3
+            - value: 5
+              count: 3
+            - value: 4
+              count: 3
+            - value: 3
+              count: 3
   comments:
     - text: Lorem ipsum… 2
     - text: Lorem ipsum… 2

--- a/test/jbuilder/schema/partials_test.rb
+++ b/test/jbuilder/schema/partials_test.rb
@@ -114,7 +114,9 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
 
   test "one-line text is defined correctly" do
     json = Jbuilder::Schema::Template.new nil
-    def json._one_line?(...) = super
+    def json._one_line?(...)
+      super
+    end
 
     one_line = <<-JBUILDER
       json.articles do
@@ -128,11 +130,11 @@ class Jbuilder::Schema::PartialsTest < ActionView::TestCase
       json.articles do
 
         # ^ Empty line
-                        
+
         # This is comment
             # This is comment with spaces
         json.partial! 'api/v1/articles/article', article: user.article
-                                          
+
         # ^ Line with spaces
       end
     JBUILDER

--- a/test/jbuilder/schema/template_test.rb
+++ b/test/jbuilder/schema/template_test.rb
@@ -273,7 +273,9 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
 
   test "schematize type" do
     json = Jbuilder::Schema::Template.new nil
-    def json._schema(...) = super # We're marking it public on the singleton, but can't use `public` since we're ultimately a BasicObject.
+    def json._schema(...)
+      super # We're marking it public on the singleton, but can't use `public` since we're ultimately a BasicObject.
+    end
 
     assert_equal({type: :integer}, json._schema(nil, 1))
     assert_equal({type: :number}, json._schema(nil, 1.5))
@@ -299,7 +301,9 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
 
   test "one-line text is defined correctly" do
     json = Jbuilder::Schema::Template.new nil
-    def json._one_line?(...) = super
+    def json._one_line?(...)
+      super
+    end
 
     one_line = <<-JBUILDER
       json.articles do
@@ -313,11 +317,11 @@ class Jbuilder::Schema::TemplateTest < ActionView::TestCase
       json.articles do
 
         # ^ Empty line
-                        
+
         # This is comment
             # This is comment with spaces
         json.partial! 'api/v1/articles/article', article: user.article
-                                          
+
         # ^ Line with spaces
       end
     JBUILDER

--- a/test/setup/active_record.rb
+++ b/test/setup/active_record.rb
@@ -59,7 +59,12 @@ class Article < ActiveRecord::Base
   has_many :ratings
   has_many :comments
 
-  enum status: %w[pending published archived].index_by(&:itself)
+  # Use hash syntax for Rails 8+, index_by for older versions
+  if Rails.version >= "8.0"
+    enum :status, { pending: "pending", published: "published", archived: "archived" }
+  else
+    enum status: %w[pending published archived].index_by(&:itself)
+  end
 
   validates_presence_of :user, :status, :title, :body
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 
+require "logger"
 require "rails"
 
 require "active_support"


### PR DESCRIPTION
Hi everyone 👋 great job on this gem!

I've been trying to add some support for non-activerecord setups #88. However, the CI was failing due to errors in the tests and in the tests against the starter_repo, this PR fixes both the test suite and modernize and fixes the CI

Summary

- Drop support for Ruby 2.6: original gemspec defines Ruby >= 2.6, However, some parts of the code is using arguments forwarding which is introduced in 2.7

- Update gemspec to officially support Ruby 2.7+ and Rails 6+ (matching the CI matrix and passing), had to remove some usages of endless methods that was introduced at 3 (we can revert this and define 3 as minimum in gemspec)

- Ruby 3.5 readiness: Add ostruct, bigdecimal, and logger as runtime dependencies since these stop shipping as default gems starting in Ruby 3.5.0.

- Rails/ActiveRecord 8 compatibility: Update test setup to accommodate the new enum declaration style in AR 8.

- SQLite3 constraint: Pin SQLite3 in the Gemfile to versions compatible with Rails 7.1+ / Ruby 3.1+. (failing original tests)

- Cleanup & packaging: Exclude Gemfile and standard.yml from gem builds.

- Fixtures: Fix YAML fixture shape (comments should be an array) and update ratings Jbuilder so ratings yield the correct comments array. (failing original tests)

- Fix CI test against starter_repo: starter_repo removed the bin that this repo used in CI to test it, used the test stage in the starter_repo, this can be cleaner if the test stage in the starter repo allows injecting a gem before test. (failing original tests)

- CI refresh: Bump GitHub Actions, enable Corepack/Yarn, broaden the Ruby/Rails matrix
